### PR TITLE
Hardening pass: precision, safety, concurrency, security, supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
         run: |
           cargo build --workspace --no-default-features
           cargo test --workspace --no-default-features
+      - name: Build and test (default features)
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: |
+          cargo build --workspace
+          cargo test --workspace
 
   test-hardware-feature:
     name: test-hardware-feature

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Install cross (Linux only)
         if: matrix.os == 'ubuntu-latest'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        # Pin to a released tag for reproducible release builds.
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5 --locked
 
       - name: Build (cross)
         if: matrix.os == 'ubuntu-latest'
@@ -64,22 +65,30 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} -p doser_cli ${{ matrix.features }}
 
       - name: Strip binary
+        # The package is `doser_cli`, so the produced binary is named `doser_cli`.
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            docker run --rm -v $(pwd):/work -w /work ubuntu:20.04 strip target/${{ matrix.target }}/release/doser || true
+            docker run --rm -v $(pwd):/work -w /work ubuntu:20.04 strip target/${{ matrix.target }}/release/doser_cli || true
           elif [ "${{ matrix.os }}" = "macos-latest" ]; then
-            strip target/${{ matrix.target }}/release/doser || true
+            strip target/${{ matrix.target }}/release/doser_cli || true
           fi
 
-      - name: Create tarball
+      - name: Create tarball and checksum
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf doser-${{ matrix.target }}.tar.gz doser
+          tar czf doser-${{ matrix.target }}.tar.gz doser_cli
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum doser-${{ matrix.target }}.tar.gz > doser-${{ matrix.target }}.tar.gz.sha256
+          else
+            shasum -a 256 doser-${{ matrix.target }}.tar.gz > doser-${{ matrix.target }}.tar.gz.sha256
+          fi
           cd ../../..
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:
-          files: target/${{ matrix.target }}/release/doser-${{ matrix.target }}.tar.gz
+          files: |
+            target/${{ matrix.target }}/release/doser-${{ matrix.target }}.tar.gz
+            target/${{ matrix.target }}/release/doser-${{ matrix.target }}.tar.gz.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive business and best practices review documentation
 - MIT and Apache-2.0 dual licensing
 - API stability notices and safety disclaimers in README
+- `doser_hardware::sim_pair()` — linked simulated scale/motor sharing per-instance
+  state (replaces process-global statics; isolates parallel simulations)
+- Regression tests asserting the motor is stopped on every safety abort
+  (overshoot, max-runtime, no-progress, E-stop)
 
 ### Fixed
 
+- **Calibration precision (critical):** the calibration gain was quantized to an
+  integer centigrams-per-count, collapsing realistic load-cell gains (e.g.
+  ~0.0005 g/count) to zero so the scale read ~0 g on real hardware. Gain is now
+  stored as a scaled integer (`fixed_point::GAIN_SCALE`) preserving sub-count
+  resolution while keeping the per-sample math integer/deterministic.
+- **Persisted calibration `offset_g`** was silently dropped when loading from TOML;
+  it is now preserved end-to-end.
+- **Ctrl-C/shutdown** is now honored in the default (non-stats) runner path; the
+  motor is stopped and the run aborts instead of running to completion.
+- **Motor-stop on abort paths** now retries best-effort and escalates to an
+  error-level log on persistent failure instead of silently ignoring the error.
+- **E-stop responsiveness in sampler mode** is decoupled from sensor read latency
+  via an out-of-band poll each orchestration iteration.
+- **E-stop GPIO checker thread** no longer leaks: it self-terminates (via a `Weak`
+  ref) when the checker is dropped, releasing the GPIO claim.
+- **Memory ordering:** the sampler stall-watchdog timestamp and the hardware motor
+  running/speed flags use Release/Acquire instead of Relaxed for reliable
+  cross-thread visibility of safety-relevant state.
+- **HX711 SCK timing:** clock edges now use a calibrated ~1µs busy-wait (was a
+  no-op `spin_loop`, below the device's ~0.2µs minimum).
 - Thread leak in background sampler (issue #1.2) - sampler threads now exit promptly on drop
 - Optimized sampler shutdown to <200ms using lock-free AtomicBool
 - Privilege escalation risk in real-time setup (issue #1.1) - improved error handling and privilege checks
 - Division by zero vulnerability in calibration loader (issue #1.3) - added validation
+- Release workflow referenced a non-existent `doser` binary (the package builds
+  `doser_cli`); release tarballs now ship the correct binary plus a `.sha256`.
 
 ### Changed
 
 - Improved error messages with actionable troubleshooting guidance
 - Enhanced RT mode setup with better fallback behavior
+- `control.hysteresis_g` is now implemented: the weight must stay within the
+  acceptance band (`max(epsilon, hysteresis)`) for `stable_ms` to settle, so a
+  noisy out-of-band reading resets the settle timer (previously parsed but unused)
+- Median prefilter uses O(n) selection (`select_nth_unstable`) instead of a full
+  sort per sample, reducing control-loop jitter
+- `Scale::read` documented as returning raw ADC counts (calibration converts to
+  grams), correcting a misleading "centigrams" claim
+
+### Security
+
+- Config validation now rejects non-finite (NaN/±Inf) float fields and caps
+  filter/predictor window sizes (heap-exhaustion guard)
+- Config file size and calibration CSV row count are now bounded
+- `install.sh` fails fast, quotes paths, and verifies a SHA-256 checksum before
+  installing the binary; `cross` and the Rust toolchain are pinned for
+  reproducible builds
 
 ## [0.1.0] - 2025-XX-XX
 

--- a/doser_cli/src/dose.rs
+++ b/doser_cli/src/dose.rs
@@ -257,6 +257,13 @@ pub fn run_dose(
                 .into());
             }
 
+            // Out-of-band E-stop poll (decoupled from sample arrival).
+            if doser.poll_estop_stop() {
+                return Err(doser_core::error::DoserError::Abort(
+                    doser_core::error::AbortReason::Estop,
+                )
+                .into());
+            }
             let t_start = std::time::Instant::now();
             let status = if let Some(raw) = sampler.latest() {
                 sample_count += 1;
@@ -310,6 +317,7 @@ pub fn run_dose(
                 prefer_timeout_first,
                 mode: sampling_mode,
                 predictor: Some(predictor_core),
+                shutdown: Some(shutdown),
             },
         )?;
         // Telemetry not available through runner; return nulls

--- a/doser_cli/src/main.rs
+++ b/doser_cli/src/main.rs
@@ -64,7 +64,18 @@ fn real_main(shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) -> eyre::R
     let cli = Cli::parse();
     let _ = JSON_MODE.set(cli.json);
 
-    // 1) Load typed config from TOML
+    // 1) Load typed config from TOML (with a size cap so a huge file can't OOM)
+    const MAX_CONFIG_BYTES: u64 = 1 << 20; // 1 MiB; real configs are a few KB.
+    if let Ok(meta) = fs::metadata(&cli.config)
+        && meta.len() > MAX_CONFIG_BYTES
+    {
+        eyre::bail!(
+            "config file {:?} is too large ({} bytes > {} byte limit)",
+            cli.config,
+            meta.len(),
+            MAX_CONFIG_BYTES
+        );
+    }
     let cfg_text = fs::read_to_string(&cli.config)
         .wrap_err_with(|| format!("read config {:?}", cli.config))?;
     let cfg: Config =
@@ -82,10 +93,9 @@ fn real_main(shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) -> eyre::R
 
     // 2) Load calibration: prefer persisted in TOML if present; else optional CSV
     let calib: Option<Calibration> = if let Some(pc) = cfg.calibration {
-        Some(Calibration {
-            offset: pc.zero_counts,
-            scale_factor: pc.gain_g_per_count,
-        })
+        // Use the From impl so the persisted additive `offset_g` is preserved
+        // (manual field construction previously dropped it).
+        Some(Calibration::from(pc))
     } else if let Some(p) = &cli.calibration {
         let c =
             load_calibration_csv(p).map_err(|e| eyre::eyre!("parse calibration {:?}: {}", p, e))?;
@@ -114,10 +124,8 @@ fn real_main(shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>) -> eyre::R
     };
 
     #[cfg(any(not(feature = "hardware"), not(target_os = "linux")))]
-    let hw = {
-        use doser_hardware::{SimulatedMotor, SimulatedScale};
-        (SimulatedScale::new(), SimulatedMotor::default())
-    };
+    // Linked sim pair so the simulated scale responds to the simulated motor.
+    let hw = doser_hardware::sim_pair();
 
     match cli.cmd {
         Commands::SelfCheck => {

--- a/doser_config/src/lib.rs
+++ b/doser_config/src/lib.rs
@@ -231,6 +231,7 @@ impl From<PersistedCalibration> for Calibration {
         Calibration {
             offset: p.zero_counts,
             scale_factor: p.gain_g_per_count,
+            offset_g: p.offset_g,
         }
     }
 }
@@ -279,8 +280,14 @@ where
 
 #[derive(Debug)]
 pub struct Calibration {
+    /// Tare baseline in raw counts (`zero_counts`).
     pub offset: i32,
+    /// Gain in grams per count.
     pub scale_factor: f32,
+    /// Additive offset in grams applied after gain (rarely needed; default 0.0).
+    /// The CSV path folds the OLS intercept into `offset` (tare), so it sets this to 0.0;
+    /// persisted TOML calibration may carry a non-zero value.
+    pub offset_g: f32,
 }
 
 impl Calibration {
@@ -375,6 +382,8 @@ impl Calibration {
         Ok(Calibration {
             offset: offset_i32,
             scale_factor: a as f32,
+            // The OLS intercept is folded into `offset` (tare counts); no extra grams offset.
+            offset_g: 0.0,
         })
     }
 }
@@ -473,8 +482,13 @@ pub fn load_calibration_csv(path: &std::path::Path) -> eyre::Result<Calibration>
         );
     }
 
+    // Bound the number of rows so a malformed/huge CSV cannot exhaust memory.
+    const MAX_CALIBRATION_ROWS: usize = 100_000;
     let mut rows = Vec::new();
     for (idx, rec) in rdr.deserialize::<CalibrationRow>().enumerate() {
+        if rows.len() >= MAX_CALIBRATION_ROWS {
+            eyre::bail!("calibration CSV has too many rows (> {MAX_CALIBRATION_ROWS})");
+        }
         match rec {
             Ok(row) => rows.push(row),
             Err(e) => {
@@ -486,6 +500,11 @@ pub fn load_calibration_csv(path: &std::path::Path) -> eyre::Result<Calibration>
     Calibration::try_from(rows)
 }
 
+/// Upper bound for filter/predictor window sizes. These size `Vec`/`VecDeque`
+/// allocations in the core, so an untrusted config must not request an
+/// unbounded window (memory-exhaustion guard). Real configs use single digits.
+const MAX_WINDOW: usize = 10_000;
+
 impl Config {
     pub fn validate(&self) -> eyre::Result<()> {
         // Control
@@ -495,25 +514,39 @@ impl Config {
         if self.control.fine_speed == 0 {
             eyre::bail!("control.fine_speed must be > 0");
         }
-        if self.control.slow_at_g.is_sign_negative() {
-            eyre::bail!("control.slow_at_g must be >= 0");
+        if !self.control.slow_at_g.is_finite() || self.control.slow_at_g < 0.0 {
+            eyre::bail!("control.slow_at_g must be finite and >= 0");
         }
-        if self.control.hysteresis_g.is_sign_negative() {
-            eyre::bail!("control.hysteresis_g must be >= 0");
+        if !self.control.hysteresis_g.is_finite() || self.control.hysteresis_g < 0.0 {
+            eyre::bail!("control.hysteresis_g must be finite and >= 0");
         }
         if self.control.stable_ms > 5 * 60 * 1000 {
             eyre::bail!("control.stable_ms is unreasonably large (>5min)");
         }
-        if self.control.epsilon_g < 0.0 || self.control.epsilon_g > 1.0 {
-            eyre::bail!("control.epsilon_g must be in [0.0, 1.0]");
+        if !self.control.epsilon_g.is_finite()
+            || self.control.epsilon_g < 0.0
+            || self.control.epsilon_g > 1.0
+        {
+            eyre::bail!("control.epsilon_g must be finite and in [0.0, 1.0]");
+        }
+        for (thr_g, sps) in &self.control.speed_bands {
+            if !thr_g.is_finite() || *thr_g < 0.0 {
+                eyre::bail!("control.speed_bands threshold must be finite and >= 0");
+            }
+            if *sps == 0 {
+                eyre::bail!("control.speed_bands sps must be > 0");
+            }
         }
 
         // Safety
-        if self.safety.max_overshoot_g < 0.0 {
-            eyre::bail!("safety.max_overshoot_g must be >= 0.0");
+        if !self.safety.max_overshoot_g.is_finite() || self.safety.max_overshoot_g < 0.0 {
+            eyre::bail!("safety.max_overshoot_g must be finite and >= 0.0");
         }
-        if self.safety.no_progress_epsilon_g <= 0.0 || self.safety.no_progress_epsilon_g > 1.0 {
-            eyre::bail!("safety.no_progress_epsilon_g must be in (0.0, 1.0]");
+        if !self.safety.no_progress_epsilon_g.is_finite()
+            || self.safety.no_progress_epsilon_g <= 0.0
+            || self.safety.no_progress_epsilon_g > 1.0
+        {
+            eyre::bail!("safety.no_progress_epsilon_g must be finite and in (0.0, 1.0]");
         }
         if self.safety.no_progress_ms == 0 {
             eyre::bail!("safety.no_progress_ms must be >= 1");
@@ -526,8 +559,14 @@ impl Config {
         if self.filter.ma_window == 0 {
             eyre::bail!("filter.ma_window must be >= 1");
         }
+        if self.filter.ma_window > MAX_WINDOW {
+            eyre::bail!("filter.ma_window must be <= {MAX_WINDOW}");
+        }
         if self.filter.median_window == 0 {
             eyre::bail!("filter.median_window must be >= 1");
+        }
+        if self.filter.median_window > MAX_WINDOW {
+            eyre::bail!("filter.median_window must be <= {MAX_WINDOW}");
         }
         if self.filter.sample_rate_hz == 0 {
             eyre::bail!("filter.sample_rate_hz must be > 0");
@@ -542,8 +581,14 @@ impl Config {
         if self.predictor.window == 0 {
             eyre::bail!("predictor.window must be >= 1");
         }
-        if self.predictor.min_progress_ratio < 0.0 || self.predictor.min_progress_ratio > 1.0 {
-            eyre::bail!("predictor.min_progress_ratio must be in [0.0, 1.0]");
+        if self.predictor.window > MAX_WINDOW {
+            eyre::bail!("predictor.window must be <= {MAX_WINDOW}");
+        }
+        if !self.predictor.min_progress_ratio.is_finite()
+            || self.predictor.min_progress_ratio < 0.0
+            || self.predictor.min_progress_ratio > 1.0
+        {
+            eyre::bail!("predictor.min_progress_ratio must be finite and in [0.0, 1.0]");
         }
 
         // Timeouts

--- a/doser_config/tests/validation.rs
+++ b/doser_config/tests/validation.rs
@@ -68,3 +68,77 @@ max_overshoot_g = 1.0
     let cfg = load_toml(toml).expect("parse TOML");
     cfg.validate().expect("valid config should pass");
 }
+
+#[test]
+fn rejects_non_finite_epsilon_g() {
+    let toml = r#"
+[pins]
+hx711_dt = 5
+hx711_sck = 6
+motor_step = 23
+motor_dir = 24
+
+[filter]
+ma_window = 3
+median_window = 3
+sample_rate_hz = 50
+
+[control]
+coarse_speed = 1200
+fine_speed = 250
+slow_at_g = 1.0
+hysteresis_g = 0.05
+stable_ms = 250
+epsilon_g = nan
+
+[timeouts]
+sample_ms = 150
+
+[safety]
+max_run_ms = 60000
+max_overshoot_g = 1.0
+no_progress_epsilon_g = 0.02
+no_progress_ms = 1200
+"#;
+
+    let cfg = load_toml(toml).expect("parse TOML");
+    let err = cfg.validate().expect_err("should reject NaN epsilon_g");
+    assert!(
+        format!("{err}").contains("epsilon_g"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rejects_oversized_filter_window() {
+    let toml = r#"
+[pins]
+hx711_dt = 5
+hx711_sck = 6
+motor_step = 23
+motor_dir = 24
+
+[filter]
+ma_window = 1000000
+median_window = 3
+sample_rate_hz = 50
+
+[timeouts]
+sample_ms = 150
+
+[safety]
+no_progress_epsilon_g = 0.02
+no_progress_ms = 1200
+max_run_ms = 60000
+max_overshoot_g = 1.0
+"#;
+
+    let cfg = load_toml(toml).expect("parse TOML");
+    let err = cfg
+        .validate()
+        .expect_err("should reject an oversized ma_window");
+    assert!(
+        format!("{err}").contains("ma_window"),
+        "unexpected error: {err}"
+    );
+}

--- a/doser_core/src/builder.rs
+++ b/doser_core/src/builder.rs
@@ -13,7 +13,7 @@ use crate::calibration::Calibration;
 use crate::config::*;
 use crate::core::DoserCore;
 use crate::error::{BuildError, Result};
-use crate::fixed_point::{grams_to_cg, quantize_to_cg_i32};
+use crate::fixed_point::{gain_to_scaled_cg_per_count, grams_to_cg, quantize_to_cg_i32};
 use crate::status::DosingStatus;
 
 // ── Public dynamic-dispatch wrapper ──────────────────────────────────────────
@@ -169,14 +169,19 @@ fn validate_and_build<S: doser_traits::Scale, M: doser_traits::Motor>(
             "target grams out of range",
         )));
     }
-    if control.hysteresis_g.is_sign_negative() {
+    if !control.hysteresis_g.is_finite() || control.hysteresis_g < 0.0 {
         return Err(eyre::Report::new(BuildError::InvalidConfig(
-            "hysteresis_g must be >= 0",
+            "hysteresis_g must be finite and >= 0",
         )));
     }
-    if control.slow_at_g.is_sign_negative() {
+    if !control.slow_at_g.is_finite() || control.slow_at_g < 0.0 {
         return Err(eyre::Report::new(BuildError::InvalidConfig(
-            "slow_at_g must be >= 0",
+            "slow_at_g must be finite and >= 0",
+        )));
+    }
+    if !control.epsilon_g.is_finite() {
+        return Err(eyre::Report::new(BuildError::InvalidConfig(
+            "epsilon_g must be finite",
         )));
     }
     if control.coarse_speed == 0 || control.fine_speed == 0 {
@@ -189,19 +194,31 @@ fn validate_and_build<S: doser_traits::Scale, M: doser_traits::Motor>(
             "sensor_ms must be >= 1",
         )));
     }
-    if safety.max_overshoot_g.is_sign_negative() {
+    if !safety.max_overshoot_g.is_finite() || safety.max_overshoot_g < 0.0 {
         return Err(eyre::Report::new(BuildError::InvalidConfig(
-            "max_overshoot_g must be >= 0",
+            "max_overshoot_g must be finite and >= 0",
         )));
     }
-    if safety.no_progress_epsilon_g.is_sign_negative() {
+    if !safety.no_progress_epsilon_g.is_finite() || safety.no_progress_epsilon_g < 0.0 {
         return Err(eyre::Report::new(BuildError::InvalidConfig(
-            "no_progress_epsilon_g must be >= 0",
+            "no_progress_epsilon_g must be finite and >= 0",
         )));
     }
     if filter.sample_rate_hz == 0 {
         return Err(eyre::Report::new(BuildError::InvalidConfig(
             "sample_rate_hz must be > 0",
+        )));
+    }
+    // Bound window sizes: they drive Vec/VecDeque allocations in the core.
+    const MAX_WINDOW: usize = 10_000;
+    if filter.ma_window > MAX_WINDOW || filter.median_window > MAX_WINDOW {
+        return Err(eyre::Report::new(BuildError::InvalidConfig(
+            "filter window sizes must be <= 10000",
+        )));
+    }
+    if predictor.window > MAX_WINDOW {
+        return Err(eyre::Report::new(BuildError::InvalidConfig(
+            "predictor window must be <= 10000",
         )));
     }
     // Validate speed band entries
@@ -246,6 +263,7 @@ fn validate_and_build<S: doser_traits::Scale, M: doser_traits::Motor>(
 
     let target_cg = grams_to_cg(target_g);
     let epsilon_cg = grams_to_cg(control.epsilon_g);
+    let hysteresis_cg = grams_to_cg(control.hysteresis_g);
     let max_overshoot_cg = grams_to_cg(safety.max_overshoot_g);
     let no_progress_epsilon_cg = grams_to_cg(safety.no_progress_epsilon_g);
     let slow_at_cg = grams_to_cg(control.slow_at_g);
@@ -255,7 +273,7 @@ fn validate_and_build<S: doser_traits::Scale, M: doser_traits::Motor>(
         .map(|(g, sps)| (grams_to_cg(*g), *sps))
         .collect();
 
-    let cal_gain_cg_per_count = quantize_to_cg_i32(calibration.gain_g_per_count);
+    let cal_gain_scaled = gain_to_scaled_cg_per_count(calibration.gain_g_per_count);
     let cal_offset_cg = quantize_to_cg_i32(calibration.offset_g);
 
     Ok(DoserCore {
@@ -277,10 +295,11 @@ fn validate_and_build<S: doser_traits::Scale, M: doser_traits::Motor>(
         tmp_med_buf: Vec::with_capacity(med_cap),
         ema_prev_cg: None,
         period_us,
-        cal_gain_cg_per_count,
+        cal_gain_scaled,
         cal_offset_cg,
         slow_at_cg,
         epsilon_cg,
+        hysteresis_cg,
         max_overshoot_cg,
         no_progress_epsilon_cg,
         motor_started: false,

--- a/doser_core/src/calibration.rs
+++ b/doser_core/src/calibration.rs
@@ -3,7 +3,7 @@
 //! The core representation uses centigrams (cg, 1 cg = 0.01 g) with `i32`
 //! fixed-point arithmetic for deterministic, allocation-free control loop math.
 
-use crate::fixed_point::quantize_to_cg_i32;
+use crate::fixed_point::{cg_from_delta_scaled, gain_to_scaled_cg_per_count, quantize_to_cg_i32};
 
 /// Simple linear calibration from raw scale counts to grams.
 ///
@@ -31,21 +31,22 @@ impl Calibration {
     ///   centigrams = round(100 * grams)
     ///
     /// Implementation (fixed-point):
-    /// - gain_cg_per_count = round(100 * gain_g_per_count)
+    /// - gain_scaled = round(100 * gain_g_per_count * GAIN_SCALE)  (cg/count × GAIN_SCALE)
     /// - offset_cg = round(100 * offset_g)
-    /// - result_cg = saturating_mul(gain_cg_per_count, raw - zero_counts) + offset_cg
+    /// - result_cg = round((raw - zero_counts) * gain_scaled / GAIN_SCALE) + offset_cg
     ///
     /// Rationale:
     /// - Avoids per-sample floating-point math in the control loop.
     /// - Keeps all controller thresholds and comparisons in one integer unit (cg).
-    /// - Uses saturating arithmetic operations (saturating_sub/mul/add) to avoid
-    ///   overflow on extreme inputs/parameters.
+    /// - The gain is stored as a *scaled* integer (see `fixed_point::GAIN_SCALE`)
+    ///   so that realistic sub-centigram-per-count gains are not rounded to zero.
+    ///   The multiply uses an `i128` intermediate and the result saturates to `i32`.
     ///
     /// Rounding and error bounds:
-    /// - `gain_g_per_count` and `offset_g` are rounded to the nearest centigram
-    ///   before use. The returned value is typically within ~0.5 cg of
-    ///   `round(100 * to_grams(raw))` given stable parameters.
-    /// - Non-finite parameters (NaN/±Inf) are treated as 0 during quantization.
+    /// - `gain_g_per_count` is preserved to ~6 extra decimal digits; `offset_g`
+    ///   is rounded to the nearest centigram. The returned value is within ~1 cg
+    ///   of `round(100 * to_grams(raw))` for stable parameters.
+    /// - Non-finite parameters (NaN/±Inf) are treated as 0.
     ///
     /// Units:
     /// - Input: `raw` is ADC counts.
@@ -55,12 +56,10 @@ impl Calibration {
     /// - If `gain_g_per_count = 0.01`, `zero_counts = 0`, `offset_g = 0.0`,
     ///   and `raw = 123`, then `to_cg(123) == 123` (i.e., 1.23 g).
     pub fn to_cg(&self, raw: i32) -> i32 {
-        let delta = raw.saturating_sub(self.zero_counts);
-        let gain_cg_per_count = quantize_to_cg_i32(self.gain_g_per_count);
+        let delta = (raw as i64) - (self.zero_counts as i64);
+        let gain_scaled = gain_to_scaled_cg_per_count(self.gain_g_per_count);
         let offset_cg = quantize_to_cg_i32(self.offset_g);
-        gain_cg_per_count
-            .saturating_mul(delta)
-            .saturating_add(offset_cg)
+        cg_from_delta_scaled(delta, gain_scaled, offset_cg)
     }
 }
 

--- a/doser_core/src/conversions.rs
+++ b/doser_core/src/conversions.rs
@@ -77,7 +77,7 @@ impl From<&doser_config::Calibration> for Calibration {
         Self {
             gain_g_per_count: c.scale_factor,
             zero_counts: c.offset,
-            offset_g: 0.0,
+            offset_g: c.offset_g,
         }
     }
 }

--- a/doser_core/src/core.rs
+++ b/doser_core/src/core.rs
@@ -40,10 +40,11 @@ pub struct DoserCore<S: doser_traits::Scale, M: doser_traits::Motor> {
     pub(crate) ema_prev_cg: Option<f32>,
     pub(crate) tmp_med_buf: Vec<i32>,
     pub(crate) period_us: u64,
-    pub(crate) cal_gain_cg_per_count: i32,
+    pub(crate) cal_gain_scaled: i64,
     pub(crate) cal_offset_cg: i32,
     pub(crate) slow_at_cg: i32,
     pub(crate) epsilon_cg: i32,
+    pub(crate) hysteresis_cg: i32,
     pub(crate) max_overshoot_cg: i32,
     pub(crate) no_progress_epsilon_cg: i32,
     pub(crate) motor_started: bool,
@@ -104,9 +105,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
     /// Process a pre-sampled raw reading (for sampler integration).
     pub fn step_from_raw(&mut self, raw: i32) -> Result<DosingStatus> {
         if self.estop_latched || self.poll_estop() {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed on estop");
-            }
+            self.motor_stop_best_effort("estop");
             return Ok(DosingStatus::Aborted(DoserError::Abort(AbortReason::Estop)));
         }
         let w_cg_raw = self.to_cg_cached(raw);
@@ -117,9 +116,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
     /// One iteration of the dosing loop (reads the scale internally).
     pub fn step(&mut self) -> Result<DosingStatus> {
         if self.estop_latched || self.poll_estop() {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed on estop");
-            }
+            self.motor_stop_best_effort("estop");
             return Ok(DosingStatus::Aborted(DoserError::Abort(AbortReason::Estop)));
         }
 
@@ -156,12 +153,39 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
         self.early_stop_at_cg = None;
     }
 
-    /// Stop the motor (best-effort).
+    /// Stop the motor, returning any hardware error (used on the success path).
     pub fn motor_stop(&mut self) -> Result<()> {
         self.motor
             .stop()
             .map_err(|e| eyre::Report::new(map_hw_error(&*e)))
             .wrap_err("motor_stop")
+    }
+
+    /// Best-effort motor stop for safety/abort paths.
+    ///
+    /// Unlike [`Self::motor_stop`], this never returns an error: the caller is
+    /// already aborting, so the goal is maximum effort to de-energize. It retries
+    /// a bounded number of times and escalates to an error-level log if every
+    /// attempt fails, so a stuck motor is loud rather than silently ignored.
+    fn motor_stop_best_effort(&mut self, ctx: &'static str) {
+        const MAX_ATTEMPTS: u32 = 3;
+        for attempt in 1..=MAX_ATTEMPTS {
+            match self.motor.stop() {
+                Ok(()) => return,
+                Err(e) => {
+                    if attempt == MAX_ATTEMPTS {
+                        tracing::error!(
+                            error = %e,
+                            ctx,
+                            attempts = attempt,
+                            "motor stop FAILED on abort path; motor may still be energized"
+                        );
+                    } else {
+                        tracing::warn!(error = %e, ctx, attempt, "motor stop failed; retrying");
+                    }
+                }
+            }
+        }
     }
 
     // ── Private: shared control loop logic ───────────────────────────────────
@@ -176,9 +200,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
 
         // Safety: hard runtime cap
         if now.saturating_sub(self.start_ms) >= self.safety.max_run_ms {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed on max-run cap");
-            }
+            self.motor_stop_best_effort("max-run cap");
             return Ok(DosingStatus::Aborted(DoserError::Abort(
                 AbortReason::MaxRuntime,
             )));
@@ -186,9 +208,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
 
         // Safety: excessive overshoot guard
         if w_cg > self.target_cg + self.max_overshoot_cg {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed on overshoot");
-            }
+            self.motor_stop_best_effort("overshoot");
             return Ok(DosingStatus::Aborted(DoserError::Abort(
                 AbortReason::Overshoot,
             )));
@@ -200,12 +220,21 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
             return Ok(DosingStatus::Running);
         }
 
-        // Completion zone: target reached (within epsilon)
+        // Completion zone: target reached (within epsilon). The motor is stopped and
+        // the weight must remain within the hysteresis acceptance band for `stable_ms`
+        // before completion is declared, so a noisy reading that dips below the band
+        // restarts the settle timer (the documented hysteresis behavior).
         if w_cg + self.epsilon_cg >= self.target_cg {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed entering settle zone");
-            }
-            if self.settled_since_ms.is_none() {
+            self.motor_stop_best_effort("entering settle zone");
+            // Acceptance half-band. Use at least `epsilon` so the epsilon-based stop
+            // point (w ≈ target - epsilon) is in-band and the timer can never stall;
+            // `hysteresis_g` widens it to reject noisy readings near the target. The
+            // weight must stay within `|target - w| <= band` for `stable_ms` to settle,
+            // so a spike outside the band resets the settle timer (documented hysteresis).
+            let band_cg = self.hysteresis_cg.max(self.epsilon_cg).unsigned_abs();
+            if abs_err_cg > band_cg {
+                self.settled_since_ms = None;
+            } else if self.settled_since_ms.is_none() {
                 self.settled_since_ms = Some(now);
             }
             if let Some(since) = self.settled_since_ms
@@ -229,9 +258,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
                 self.last_progress_cg = w_cg;
                 self.last_progress_at_ms = now;
             } else if now.saturating_sub(self.last_progress_at_ms) >= self.safety.no_progress_ms {
-                if let Err(e) = self.motor_stop() {
-                    tracing::warn!(error = %e, "motor_stop failed on no-progress watchdog");
-                }
+                self.motor_stop_best_effort("no-progress watchdog");
                 return Ok(DosingStatus::Aborted(DoserError::Abort(
                     AbortReason::NoProgress,
                 )));
@@ -306,10 +333,24 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
 
     #[inline]
     fn to_cg_cached(&self, raw: i32) -> i32 {
-        let delta = raw.saturating_sub(self.calibration.zero_counts);
-        self.cal_gain_cg_per_count
-            .saturating_mul(delta)
-            .saturating_add(self.cal_offset_cg)
+        let delta = (raw as i64) - (self.calibration.zero_counts as i64);
+        crate::fixed_point::cg_from_delta_scaled(delta, self.cal_gain_scaled, self.cal_offset_cg)
+    }
+
+    /// Out-of-band E-stop poll for orchestrators (e.g. the sampler runner).
+    ///
+    /// In sampler mode the control loop only runs `step_from_raw` when a sample
+    /// arrives, so E-stop response would otherwise be coupled to sensor latency
+    /// (up to the read timeout). Calling this each orchestration iteration keeps
+    /// the response time bounded by the loop period instead. Returns true if
+    /// E-stop is (or becomes) latched, stopping the motor best-effort.
+    pub fn poll_estop_stop(&mut self) -> bool {
+        if self.estop_latched || self.poll_estop() {
+            self.motor_stop_best_effort("estop (out-of-band)");
+            true
+        } else {
+            false
+        }
     }
 
     /// Poll the E-stop input with debounce; returns true if latched.
@@ -344,7 +385,6 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
             }
             self.tmp_med_buf.clear();
             self.tmp_med_buf.extend(self.med_buf.iter().copied());
-            self.tmp_med_buf.sort_unstable();
             let n = self.tmp_med_buf.len();
             #[cfg(debug_assertions)]
             {
@@ -354,12 +394,17 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
                 debug_assert!(n <= med_win, "median buffer exceeded window size");
             }
             let mid = n / 2;
+            // O(n) selection rather than a full O(n log n) sort: same result, less
+            // per-sample work and jitter on the control loop.
             if n.is_multiple_of(2) {
-                let a = self.tmp_med_buf[mid - 1];
-                let b = self.tmp_med_buf[mid];
-                avg2_round_nearest_i32(a, b)
+                let (lo, mid_val, _) = self.tmp_med_buf.select_nth_unstable(mid);
+                let mid_val = *mid_val;
+                // Even window: the lower-middle order statistic is the max of the
+                // lower partition (non-empty since mid >= 1 when n is even and > 0).
+                let lower = lo.iter().copied().max().unwrap_or(mid_val);
+                avg2_round_nearest_i32(lower, mid_val)
             } else {
-                self.tmp_med_buf[mid]
+                *self.tmp_med_buf.select_nth_unstable(mid).1
             }
         } else {
             w_cg
@@ -474,9 +519,7 @@ impl<S: doser_traits::Scale, M: doser_traits::Motor> DoserCore<S, M> {
             .saturating_add(inflight_cg)
             .saturating_add(self.epsilon_cg);
         if predicted >= self.target_cg {
-            if let Err(e) = self.motor_stop() {
-                tracing::warn!(error = %e, "motor_stop failed on predictor early-stop");
-            }
+            self.motor_stop_best_effort("predictor early-stop");
             self.early_stop_at_cg = Some(w_cg);
             tracing::debug!(
                 w_cg,

--- a/doser_core/src/fixed_point.rs
+++ b/doser_core/src/fixed_point.rs
@@ -57,6 +57,66 @@ pub fn grams_to_cg(g: f32) -> i32 {
     ((g * 100.0).round()) as i32
 }
 
+/// Fixed-point scaling applied to the calibration gain (centigrams-per-count)
+/// before it is stored as an integer.
+///
+/// A plain `round(100 * gain_g_per_count)` (integer cg/count) destroys all
+/// sub-centigram-per-count resolution. Realistic load cells have gains far below
+/// 0.005 g/count (e.g. ~5e-4 g/count for ~100 g over a 24-bit ADC span), which
+/// would quantize to `0` — making every reading collapse to the offset. Scaling
+/// the gain by this factor keeps ~6 extra decimal digits of resolution while the
+/// per-sample multiply stays integer (i128) and deterministic.
+pub const GAIN_SCALE: i64 = 1_000_000;
+
+/// Quantize a gain expressed in grams-per-count into a scaled integer of
+/// `centigrams-per-count * GAIN_SCALE`, rounding to nearest and clamping to the
+/// `i64` range. Non-finite inputs (NaN/±Inf) map to `0`.
+#[inline]
+pub fn gain_to_scaled_cg_per_count(gain_g_per_count: f32) -> i64 {
+    if !gain_g_per_count.is_finite() {
+        return 0;
+    }
+    // cg-per-count = 100 * g-per-count; scale up for fractional resolution.
+    let scaled = ((gain_g_per_count as f64) * 100.0 * (GAIN_SCALE as f64)).round();
+    if scaled >= i64::MAX as f64 {
+        i64::MAX
+    } else if scaled <= i64::MIN as f64 {
+        i64::MIN
+    } else {
+        scaled as i64
+    }
+}
+
+/// Convert a raw-count delta to centigrams using a scaled gain (see
+/// [`GAIN_SCALE`]) plus an integer centigram offset, rounding to nearest with
+/// ties away from zero and saturating to the `i32` range.
+///
+/// Uses an `i128` intermediate so the multiply cannot overflow for any `i64`
+/// delta and gain.
+#[inline]
+pub fn cg_from_delta_scaled(
+    delta_counts: i64,
+    gain_scaled_cg_per_count: i64,
+    offset_cg: i32,
+) -> i32 {
+    let num = (delta_counts as i128) * (gain_scaled_cg_per_count as i128);
+    let den = GAIN_SCALE as i128;
+    let half = den / 2;
+    let q = if num >= 0 {
+        (num + half) / den
+    } else {
+        (num - half) / den
+    };
+    let cg = q + (offset_cg as i128);
+    if cg > i32::MAX as i128 {
+        i32::MAX
+    } else if cg < i32::MIN as i128 {
+        i32::MIN
+    } else {
+        cg as i32
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +147,34 @@ mod tests {
         assert_eq!(avg2_round_nearest_i32(-1, 0), -1);
         assert_eq!(avg2_round_nearest_i32(10, 10), 10);
         assert_eq!(avg2_round_nearest_i32(-5, -6), -6);
+    }
+
+    #[test]
+    fn scaled_gain_preserves_small_gains() {
+        // Sim/test gain: 0.01 g/count -> exactly 1 cg/count.
+        assert_eq!(gain_to_scaled_cg_per_count(0.01), GAIN_SCALE);
+        // Realistic load cell from the README example: 100 g over 182000 counts.
+        let gain = 100.0_f32 / 182_000.0; // ~0.000549 g/count
+        let scaled = gain_to_scaled_cg_per_count(gain);
+        assert!(scaled > 0, "small gain must not quantize to zero");
+        // 182000 counts from zero must read ~100.00 g (10000 cg), not 0.
+        let cg = cg_from_delta_scaled(182_000, scaled, 0);
+        assert!((9995..=10005).contains(&cg), "expected ~10000 cg, got {cg}");
+        // Non-finite gain is treated as zero gain.
+        assert_eq!(gain_to_scaled_cg_per_count(f32::NAN), 0);
+        assert_eq!(gain_to_scaled_cg_per_count(f32::INFINITY), 0);
+    }
+
+    #[test]
+    fn cg_from_delta_rounds_and_saturates() {
+        // 1 cg/count, delta 123 -> 123 cg, plus offset.
+        assert_eq!(cg_from_delta_scaled(123, GAIN_SCALE, 0), 123);
+        assert_eq!(cg_from_delta_scaled(123, GAIN_SCALE, 7), 130);
+        // Round to nearest, ties away from zero.
+        assert_eq!(cg_from_delta_scaled(1, GAIN_SCALE / 2, 0), 1); // 0.5 -> 1
+        assert_eq!(cg_from_delta_scaled(-1, GAIN_SCALE / 2, 0), -1); // -0.5 -> -1
+        // Saturation on extreme gain/delta.
+        assert_eq!(cg_from_delta_scaled(i64::MAX, i64::MAX, 0), i32::MAX);
+        assert_eq!(cg_from_delta_scaled(i64::MIN, i64::MAX, 0), i32::MIN);
     }
 }

--- a/doser_core/src/runner.rs
+++ b/doser_core/src/runner.rs
@@ -9,7 +9,17 @@ use crate::error::{AbortReason, DoserError, Result as CoreResult};
 use crate::sampler::Sampler;
 use crate::status::DosingStatus;
 use doser_traits::clock::MonotonicClock;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// Shared cooperative-shutdown flag (e.g. set by a Ctrl-C handler).
+pub type ShutdownFlag = Arc<AtomicBool>;
+
+#[inline]
+fn shutdown_requested(flag: &Option<ShutdownFlag>) -> bool {
+    flag.as_ref().is_some_and(|f| f.load(Ordering::Relaxed))
+}
 
 /// How sampling should be orchestrated
 #[derive(Debug, Clone, Copy)]
@@ -35,6 +45,9 @@ pub struct RunParams {
     pub prefer_timeout_first: bool,
     pub mode: SamplingMode,
     pub predictor: Option<crate::PredictorCfg>,
+    /// Optional cooperative shutdown flag; when set true mid-run the motor is
+    /// stopped and the run aborts with `AbortReason::Estop`.
+    pub shutdown: Option<ShutdownFlag>,
 }
 
 /// Compute the stall watchdog threshold in milliseconds.
@@ -123,6 +136,7 @@ where
             estop_check,
             params.estop_debounce_n,
             params.predictor,
+            params.shutdown,
         ),
         SamplingMode::Event | SamplingMode::Paced(_) => run_with_sampler(
             scale,
@@ -138,6 +152,7 @@ where
             params.prefer_timeout_first,
             params.mode,
             params.predictor,
+            params.shutdown,
         ),
     }
 }
@@ -155,6 +170,7 @@ fn run_direct<S, M>(
     estop_check: Option<Box<dyn Fn() -> bool + Send + Sync>>,
     estop_debounce_n: u8,
     predictor: Option<crate::PredictorCfg>,
+    shutdown: Option<ShutdownFlag>,
 ) -> CoreResult<f32>
 where
     S: doser_traits::Scale + 'static,
@@ -180,6 +196,15 @@ where
     tracing::info!(target_g, mode = "direct", "dose start");
 
     loop {
+        if shutdown_requested(&shutdown) {
+            if let Err(e) = doser.motor_stop() {
+                tracing::warn!(error = %e, "motor_stop failed on shutdown");
+            }
+            tracing::info!("shutdown requested; aborting dose");
+            return Err(crate::error::Report::new(DoserError::Abort(
+                AbortReason::Estop,
+            )));
+        }
         match doser.step()? {
             DosingStatus::Running => continue,
             DosingStatus::Complete => {
@@ -211,6 +236,7 @@ fn run_with_sampler<S, M>(
     prefer_timeout_first: bool,
     mode: SamplingMode,
     predictor: Option<crate::PredictorCfg>,
+    shutdown: Option<ShutdownFlag>,
 ) -> CoreResult<f32>
 where
     S: doser_traits::Scale + Send + 'static,
@@ -259,6 +285,22 @@ where
 
     let start = std::time::Instant::now();
     loop {
+        if shutdown_requested(&shutdown) {
+            if let Err(e) = doser.motor_stop() {
+                tracing::warn!(error = %e, "motor_stop failed on shutdown");
+            }
+            tracing::info!("shutdown requested; aborting dose");
+            return Err(crate::error::Report::new(DoserError::Abort(
+                AbortReason::Estop,
+            )));
+        }
+        // Out-of-band E-stop poll: decouples E-stop latency from sample arrival.
+        if doser.poll_estop_stop() {
+            tracing::error!("E-stop latched");
+            return Err(crate::error::Report::new(DoserError::Abort(
+                AbortReason::Estop,
+            )));
+        }
         let elapsed_ms: u64 = {
             let ms = start.elapsed().as_millis();
             (ms.min(u128::from(u64::MAX))) as u64

--- a/doser_core/src/sampler.rs
+++ b/doser_core/src/sampler.rs
@@ -54,7 +54,8 @@ impl Sampler {
                             break;
                         }
                         let now = clock.ms_since(epoch);
-                        last_ok_clone.store(now, Ordering::Relaxed);
+                        // Release so the watchdog reader (Acquire) observes a fresh timestamp.
+                        last_ok_clone.store(now, Ordering::Release);
                     }
                     Err(_) => {
                         // Optional: send special value or skip; controller has watchdog
@@ -109,7 +110,8 @@ impl Sampler {
                             break;
                         }
                         let now = clock.ms_since(epoch);
-                        last_ok_clone.store(now, Ordering::Relaxed);
+                        // Release so the watchdog reader (Acquire) observes a fresh timestamp.
+                        last_ok_clone.store(now, Ordering::Release);
                     }
                     Err(_) => {
                         // On timeout or transient error, just continue; controller will watchdog
@@ -138,7 +140,7 @@ impl Sampler {
         self.rx.try_iter().last()
     }
     pub fn stalled_for(&self, now_ms: u64) -> u64 {
-        now_ms.saturating_sub(self.last_ok.load(Ordering::Relaxed))
+        now_ms.saturating_sub(self.last_ok.load(Ordering::Acquire))
     }
     /// Convenience helper: compute stall using this sampler's epoch and a real monotonic clock.
     pub fn stalled_for_now(&self) -> u64 {
@@ -147,7 +149,7 @@ impl Sampler {
             let ms = dur.as_millis();
             (ms.min(u128::from(u64::MAX))) as u64
         };
-        now_ms.saturating_sub(self.last_ok.load(Ordering::Relaxed))
+        now_ms.saturating_sub(self.last_ok.load(Ordering::Acquire))
     }
 }
 

--- a/doser_core/tests/doser.rs
+++ b/doser_core/tests/doser.rs
@@ -683,9 +683,10 @@ fn overshoot_epsilon_regression() {
     };
 
     // epsilon 0.0
+    let (scale_zero, motor_zero) = doser_hardware::sim_pair();
     let mut doser_zero = Doser::builder()
-        .with_scale(doser_hardware::sim::SimulatedScale::new())
-        .with_motor(doser_hardware::sim::SimulatedMotor::default())
+        .with_scale(scale_zero)
+        .with_motor(motor_zero)
         .with_filter(base_filter.clone())
         .with_control(ControlCfg {
             epsilon_g: 0.0,
@@ -707,9 +708,10 @@ fn overshoot_epsilon_regression() {
     }
 
     // epsilon 0.08
+    let (scale_eps, motor_eps) = doser_hardware::sim_pair();
     let mut doser_eps = Doser::builder()
-        .with_scale(doser_hardware::sim::SimulatedScale::new())
-        .with_motor(doser_hardware::sim::SimulatedMotor::default())
+        .with_scale(scale_eps)
+        .with_motor(motor_eps)
         .with_filter(base_filter)
         .with_control(ControlCfg {
             epsilon_g: 0.08,

--- a/doser_core/tests/epsilon_validation.rs
+++ b/doser_core/tests/epsilon_validation.rs
@@ -41,5 +41,8 @@ fn builder_rejects_negative_no_progress_epsilon() {
         .try_build()
         .expect_err("expected invalid config");
     let s = format!("{err}");
-    assert!(s.contains("no_progress_epsilon_g must be >= 0"));
+    assert!(
+        s.contains("no_progress_epsilon_g") && s.contains(">= 0"),
+        "unexpected error: {s}"
+    );
 }

--- a/doser_core/tests/hardening.rs
+++ b/doser_core/tests/hardening.rs
@@ -1,0 +1,366 @@
+//! Regression tests for the hardening pass:
+//! - the motor is actually stopped on every safety-abort path,
+//! - persisted calibration `offset_g` survives the conversion pipeline,
+//! - realistic small calibration gains are no longer quantized to zero,
+//! - hysteresis resets the settle timer on out-of-band (noisy) readings.
+
+use std::error::Error;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use doser_core::error::{AbortReason, DoserError};
+use doser_core::{Calibration, ControlCfg, Doser, DosingStatus, FilterCfg, SafetyCfg, Timeouts};
+use doser_traits::clock::Clock;
+use doser_traits::{Motor, Scale};
+
+/// Deterministic clock: `sleep` advances a virtual offset instead of blocking,
+/// so time-based safety paths (max-run, no-progress, settle) are reproducible.
+#[derive(Clone)]
+struct ManualClock {
+    origin: Instant,
+    offset: Arc<Mutex<Duration>>,
+}
+impl ManualClock {
+    fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+            offset: Arc::new(Mutex::new(Duration::ZERO)),
+        }
+    }
+}
+impl Clock for ManualClock {
+    fn now(&self) -> Instant {
+        self.origin + *self.offset.lock().unwrap()
+    }
+    fn sleep(&self, d: Duration) {
+        *self.offset.lock().unwrap() += d;
+    }
+}
+
+/// Motor that records whether `stop()` was called (observable after the run via
+/// a cloned `Arc`, since the builder takes ownership of the motor).
+#[derive(Clone, Default)]
+struct RecordingMotor {
+    stopped: Arc<AtomicBool>,
+}
+impl Motor for RecordingMotor {
+    fn start(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+    fn set_speed(&mut self, _sps: u32) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+    fn stop(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.stopped.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// Scale returning a constant raw reading.
+struct ConstScale(i32);
+impl Scale for ConstScale {
+    fn read(&mut self, _t: Duration) -> Result<i32, Box<dyn Error + Send + Sync>> {
+        Ok(self.0)
+    }
+}
+
+/// Scale returning a fixed sequence, then repeating the last value.
+struct SeqScale {
+    seq: Vec<i32>,
+    idx: usize,
+}
+impl Scale for SeqScale {
+    fn read(&mut self, _t: Duration) -> Result<i32, Box<dyn Error + Send + Sync>> {
+        let v = self
+            .seq
+            .get(self.idx)
+            .copied()
+            .unwrap_or_else(|| self.seq.last().copied().unwrap_or(0));
+        self.idx += 1;
+        Ok(v)
+    }
+}
+
+/// `gain = 1.0 g/count` makes raw counts equal grams, for readable test values.
+fn unit_cal() -> Calibration {
+    Calibration {
+        gain_g_per_count: 1.0,
+        zero_counts: 0,
+        offset_g: 0.0,
+    }
+}
+
+fn passthrough_filter(sample_rate_hz: u32) -> FilterCfg {
+    FilterCfg {
+        ma_window: 1,
+        median_window: 1,
+        sample_rate_hz,
+        ema_alpha: 0.0,
+    }
+}
+
+fn run_to_terminal(mut doser: Doser, max_steps: usize) -> DosingStatus {
+    doser.begin();
+    for _ in 0..max_steps {
+        match doser.step().expect("step ok") {
+            DosingStatus::Running => continue,
+            other => return other,
+        }
+    }
+    panic!("did not reach a terminal status within {max_steps} steps");
+}
+
+#[test]
+fn motor_stops_on_overshoot() {
+    let stopped = Arc::new(AtomicBool::new(false));
+    let doser = Doser::builder()
+        .with_scale(ConstScale(10)) // 10 g, well over target+overshoot
+        .with_motor(RecordingMotor {
+            stopped: stopped.clone(),
+        })
+        .with_filter(passthrough_filter(100))
+        .with_control(ControlCfg {
+            speed_bands: vec![],
+            ..ControlCfg::default()
+        })
+        .with_safety(SafetyCfg {
+            max_run_ms: 60_000,
+            max_overshoot_g: 1.0,
+            no_progress_epsilon_g: 0.0,
+            no_progress_ms: 0,
+        })
+        .with_calibration(unit_cal())
+        .with_timeouts(Timeouts { sensor_ms: 5 })
+        .with_target_grams(5.0)
+        .with_clock(Box::new(ManualClock::new()))
+        .build()
+        .unwrap();
+
+    let status = run_to_terminal(doser, 16);
+    assert!(
+        matches!(
+            status,
+            DosingStatus::Aborted(DoserError::Abort(AbortReason::Overshoot))
+        ),
+        "expected Overshoot abort"
+    );
+    assert!(
+        stopped.load(Ordering::SeqCst),
+        "motor must be stopped on overshoot"
+    );
+}
+
+#[test]
+fn motor_stops_on_estop() {
+    let stopped = Arc::new(AtomicBool::new(false));
+    let doser = Doser::builder()
+        .with_scale(ConstScale(1))
+        .with_motor(RecordingMotor {
+            stopped: stopped.clone(),
+        })
+        .with_filter(passthrough_filter(100))
+        .with_control(ControlCfg {
+            speed_bands: vec![],
+            ..ControlCfg::default()
+        })
+        .with_safety(SafetyCfg::default())
+        .with_calibration(unit_cal())
+        .with_timeouts(Timeouts { sensor_ms: 5 })
+        .with_target_grams(5.0)
+        .with_estop_check(|| true)
+        .with_estop_debounce(1)
+        .with_clock(Box::new(ManualClock::new()))
+        .build()
+        .unwrap();
+
+    let status = run_to_terminal(doser, 16);
+    assert!(
+        matches!(
+            status,
+            DosingStatus::Aborted(DoserError::Abort(AbortReason::Estop))
+        ),
+        "expected Estop abort"
+    );
+    assert!(
+        stopped.load(Ordering::SeqCst),
+        "motor must be stopped on E-stop"
+    );
+}
+
+#[test]
+fn motor_stops_on_max_runtime() {
+    let stopped = Arc::new(AtomicBool::new(false));
+    let doser = Doser::builder()
+        .with_scale(ConstScale(1)) // never reaches the 5 g target
+        .with_motor(RecordingMotor {
+            stopped: stopped.clone(),
+        })
+        .with_filter(passthrough_filter(100)) // 10 ms period
+        .with_control(ControlCfg {
+            speed_bands: vec![],
+            ..ControlCfg::default()
+        })
+        .with_safety(SafetyCfg {
+            max_run_ms: 50,
+            max_overshoot_g: 2.0,
+            no_progress_epsilon_g: 0.0,
+            no_progress_ms: 0,
+        })
+        .with_calibration(unit_cal())
+        .with_timeouts(Timeouts { sensor_ms: 5 })
+        .with_target_grams(5.0)
+        .with_clock(Box::new(ManualClock::new()))
+        .build()
+        .unwrap();
+
+    let status = run_to_terminal(doser, 1000);
+    assert!(
+        matches!(
+            status,
+            DosingStatus::Aborted(DoserError::Abort(AbortReason::MaxRuntime))
+        ),
+        "expected MaxRuntime abort"
+    );
+    assert!(
+        stopped.load(Ordering::SeqCst),
+        "motor must be stopped on max-runtime"
+    );
+}
+
+#[test]
+fn motor_stops_on_no_progress() {
+    let stopped = Arc::new(AtomicBool::new(false));
+    let doser = Doser::builder()
+        .with_scale(ConstScale(1)) // registers once, then never changes
+        .with_motor(RecordingMotor {
+            stopped: stopped.clone(),
+        })
+        .with_filter(passthrough_filter(100))
+        .with_control(ControlCfg {
+            speed_bands: vec![],
+            ..ControlCfg::default()
+        })
+        .with_safety(SafetyCfg {
+            max_run_ms: 10_000,
+            max_overshoot_g: 2.0,
+            no_progress_epsilon_g: 0.05,
+            no_progress_ms: 50,
+        })
+        .with_calibration(unit_cal())
+        .with_timeouts(Timeouts { sensor_ms: 5 })
+        .with_target_grams(5.0)
+        .with_clock(Box::new(ManualClock::new()))
+        .build()
+        .unwrap();
+
+    let status = run_to_terminal(doser, 1000);
+    assert!(
+        matches!(
+            status,
+            DosingStatus::Aborted(DoserError::Abort(AbortReason::NoProgress))
+        ),
+        "expected NoProgress abort"
+    );
+    assert!(
+        stopped.load(Ordering::SeqCst),
+        "motor must be stopped on no-progress"
+    );
+}
+
+#[test]
+fn persisted_offset_g_survives_conversion() {
+    use doser_config::{Calibration as CfgCal, PersistedCalibration};
+
+    let pc = PersistedCalibration {
+        gain_g_per_count: 0.01,
+        zero_counts: 100,
+        offset_g: 0.5,
+    };
+    // PersistedCalibration -> doser_config::Calibration keeps offset_g (previously dropped).
+    let cfg_cal = CfgCal::from(pc);
+    assert!((cfg_cal.offset_g - 0.5).abs() < 1e-6);
+    // doser_config::Calibration -> doser_core::Calibration keeps offset_g.
+    let core_cal = Calibration::from(&cfg_cal);
+    assert!((core_cal.offset_g - 0.5).abs() < 1e-6);
+    // ...and it is actually applied: at zero delta, to_cg == offset (0.5 g = 50 cg).
+    assert_eq!(core_cal.to_cg(100), 50);
+}
+
+#[test]
+fn small_gain_calibration_reads_correctly() {
+    // README example: 100 g spans 182000 counts -> ~0.000549 g/count. The old
+    // integer-cg/count quantization collapsed this to 0; the scaled fixed-point
+    // must read ~100 g (10000 cg).
+    let cal = Calibration {
+        gain_g_per_count: 100.0 / 182_000.0,
+        zero_counts: 0,
+        offset_g: 0.0,
+    };
+    let cg = cal.to_cg(182_000);
+    assert!((cg - 10_000).abs() <= 5, "expected ~10000 cg, got {cg}");
+
+    // A tiny gain the old code would zero out still yields a nonzero reading.
+    let tiny = Calibration {
+        gain_g_per_count: 0.0001,
+        zero_counts: 0,
+        offset_g: 0.0,
+    };
+    assert!(tiny.to_cg(100_000) > 0);
+}
+
+/// Run an in-band-then-spike sequence and return the number of steps to complete.
+fn steps_to_complete(readings: Vec<i32>) -> usize {
+    let mut doser = Doser::builder()
+        .with_scale(SeqScale {
+            seq: readings,
+            idx: 0,
+        })
+        .with_motor(RecordingMotor::default())
+        .with_filter(passthrough_filter(100)) // 10 ms period
+        .with_control(ControlCfg {
+            speed_bands: vec![],
+            slow_at_g: 1.0,
+            hysteresis_g: 0.2, // ±0.2 g acceptance band
+            stable_ms: 30,     // 3 periods in-band required
+            coarse_speed: 1200,
+            fine_speed: 250,
+            epsilon_g: 0.0,
+        })
+        .with_safety(SafetyCfg {
+            max_run_ms: 100_000,
+            max_overshoot_g: 5.0, // tolerate the spike without an overshoot abort
+            no_progress_epsilon_g: 0.0,
+            no_progress_ms: 0,
+        })
+        .with_calibration(unit_cal())
+        .with_timeouts(Timeouts { sensor_ms: 5 })
+        .with_target_grams(10.0)
+        .with_clock(Box::new(ManualClock::new()))
+        .build()
+        .unwrap();
+
+    doser.begin();
+    for step in 1..=1000 {
+        match doser.step().expect("step ok") {
+            DosingStatus::Running => {}
+            DosingStatus::Complete => return step,
+            DosingStatus::Aborted(e) => panic!("unexpected abort: {e}"),
+        }
+    }
+    panic!("did not complete");
+}
+
+#[test]
+fn hysteresis_resets_settle_timer_on_out_of_band_spike() {
+    // Baseline: stays in band -> settles quickly.
+    let baseline = steps_to_complete(vec![9, 10]);
+    // Same approach but with one out-of-band spike (13 g, |err| = 3 g > 0.2 g band)
+    // mid-settle: it must reset the timer, so completion takes strictly longer.
+    let with_spike = steps_to_complete(vec![9, 10, 10, 13, 10]);
+    assert!(
+        with_spike > baseline,
+        "out-of-band spike should delay settle (baseline={baseline}, with_spike={with_spike})"
+    );
+}

--- a/doser_hardware/src/hx711.rs
+++ b/doser_hardware/src/hx711.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use tracing::trace;
 
 use crate::error::Result;
-use crate::util::wait_until_low_with_timeout;
+use crate::util::{busy_wait_min_1us, wait_until_low_with_timeout};
 use doser_traits::clock::MonotonicClock;
 
 pub struct Hx711 {
@@ -45,23 +45,23 @@ impl Hx711 {
             &clock,
         )?;
 
-        // Clock out 24 bits
+        // Clock out 24 bits. The HX711 requires SCK high/low times ≥ ~0.2µs and
+        // samples DT while SCK is high, so each edge is followed by a ~1µs busy-wait.
         let mut value: i32 = 0;
         for _ in 0..24 {
             self.sck.set_high();
-            // short, consistent timing
-            spin_delay_100ns();
-            value = (value << 1) | if self.dt.is_high() { 1 } else { 0 };
+            busy_wait_min_1us();
+            value = (value << 1) | i32::from(self.dt.is_high());
             self.sck.set_low();
-            spin_delay_100ns();
+            busy_wait_min_1us();
         }
 
         // Pulse gain to set next measurement
         for _ in 0..self.gain_pulses {
             self.sck.set_high();
-            spin_delay_100ns();
+            busy_wait_min_1us();
             self.sck.set_low();
-            spin_delay_100ns();
+            busy_wait_min_1us();
         }
 
         // Sign extend 24-bit
@@ -71,10 +71,4 @@ impl Hx711 {
         trace!(raw = value, "hx711 raw read");
         Ok(value)
     }
-}
-
-#[inline(always)]
-fn spin_delay_100ns() {
-    // Do nothing; a few CPU cycles—tweak if needed.
-    std::hint::spin_loop();
 }

--- a/doser_hardware/src/lib.rs
+++ b/doser_hardware/src/lib.rs
@@ -31,15 +31,31 @@ mod hx711;
 pub mod sim {
     use doser_traits::{Motor, Scale};
     use std::error::Error;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::time::Duration;
 
-    static SIM_RUNNING: AtomicBool = AtomicBool::new(false);
-    static SIM_SPS: AtomicU32 = AtomicU32::new(0);
+    /// State shared by a linked simulated scale and motor, so the scale's reading
+    /// responds to the motor running. Each linked pair owns its own state, which
+    /// keeps independent simulations (e.g. parallel tests) isolated — unlike the
+    /// previous process-global statics.
+    #[derive(Debug, Default)]
+    struct SimState {
+        running: AtomicBool,
+        sps: AtomicU32,
+    }
 
-    /// Minimal simulated scale that increments by an optional env-configured delta while running.
+    impl SimState {
+        fn shared() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+    }
+
+    /// Minimal simulated scale that increments by an optional env-configured delta
+    /// (`DOSER_TEST_SIM_INC`) on each read while the linked motor is running.
     pub struct SimulatedScale {
         grams: f32,
+        state: Arc<SimState>,
     }
 
     impl Default for SimulatedScale {
@@ -49,8 +65,17 @@ pub mod sim {
     }
 
     impl SimulatedScale {
+        /// Create an unlinked scale (no motor coupling). Use [`sim_pair`] to link a
+        /// scale and motor so the reading responds to the motor running.
         pub fn new() -> Self {
-            Self { grams: 0.0 }
+            Self {
+                grams: 0.0,
+                state: SimState::shared(),
+            }
+        }
+
+        fn with_state(state: Arc<SimState>) -> Self {
+            Self { grams: 0.0, state }
         }
     }
 
@@ -75,8 +100,8 @@ pub mod sim {
                 .ok()
                 .and_then(|s| s.parse::<f32>().ok())
                 .unwrap_or(0.0);
-            if SIM_RUNNING.load(Ordering::Relaxed) && delta != 0.0 {
-                let _sps = SIM_SPS.load(Ordering::Relaxed);
+            if self.state.running.load(Ordering::Acquire) && delta != 0.0 {
+                let _sps = self.state.sps.load(Ordering::Acquire);
                 // Keep it simple for now: one delta per read while running
                 self.grams = (self.grams + delta).max(0.0);
             }
@@ -85,35 +110,50 @@ pub mod sim {
         }
     }
 
-    /// Minimal simulated motor; tracks speed and running state.
+    /// Minimal simulated motor; drives the shared [`SimState`] consumed by the scale.
     #[derive(Default)]
     pub struct SimulatedMotor {
-        speed_sps: u32,
-        running: bool,
+        state: Arc<SimState>,
+    }
+
+    impl SimulatedMotor {
+        /// Create an unlinked motor. Use [`sim_pair`] to link a scale and motor.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        fn with_state(state: Arc<SimState>) -> Self {
+            Self { state }
+        }
     }
 
     impl Motor for SimulatedMotor {
         fn start(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            self.running = true;
-            SIM_RUNNING.store(true, Ordering::Relaxed);
+            self.state.running.store(true, Ordering::Release);
             Ok(())
         }
 
         fn set_speed(&mut self, sps: u32) -> Result<(), Box<dyn Error + Send + Sync>> {
-            // You can enforce "must start first" semantics if you want:
-            // if !self.running { return Err("motor not started".into()); }
-            self.speed_sps = sps;
-            SIM_SPS.store(sps, Ordering::Relaxed);
+            self.state.sps.store(sps, Ordering::Release);
             Ok(())
         }
 
         fn stop(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            self.speed_sps = 0;
-            self.running = false;
-            SIM_SPS.store(0, Ordering::Relaxed);
-            SIM_RUNNING.store(false, Ordering::Relaxed);
+            self.state.sps.store(0, Ordering::Release);
+            self.state.running.store(false, Ordering::Release);
             Ok(())
         }
+    }
+
+    /// Create a linked simulated `(scale, motor)` pair that share state, so the
+    /// scale's reading responds to the motor running. Each pair is independent,
+    /// keeping parallel simulations (e.g. tests) isolated.
+    pub fn sim_pair() -> (SimulatedScale, SimulatedMotor) {
+        let state = SimState::shared();
+        (
+            SimulatedScale::with_state(state.clone()),
+            SimulatedMotor::with_state(state),
+        )
     }
 }
 
@@ -498,8 +538,10 @@ pub mod hardware {
                         break;
                     }
 
-                    let is_running = running_bg.load(Ordering::Relaxed);
-                    let sps_val = sps_bg.load(Ordering::Relaxed).clamp(0, 5_000);
+                    // Acquire pairs with the Release stores in start/stop/set_speed so the
+                    // stepping thread promptly observes commanded state changes.
+                    let is_running = running_bg.load(Ordering::Acquire);
+                    let sps_val = sps_bg.load(Ordering::Acquire).clamp(0, 5_000);
                     if !(is_running && sps_val > 0) {
                         clock.sleep(Duration::from_millis(2));
                         pacer.reset();
@@ -510,12 +552,12 @@ pub mod hardware {
                     // Rising edge
                     let _ = step.set_high();
                     spin_delay_min();
-                    busy_wait_min_1us();
+                    crate::util::busy_wait_min_1us();
                     // High hold until mid, then fall and hold until end
                     if let Some(avg) = pacer.step_with(&sleeper, period_us, || {
                         let _ = step.set_low();
                         spin_delay_min();
-                        busy_wait_min_1us();
+                        crate::util::busy_wait_min_1us();
                     }) {
                         avg_jitter_us_bg.store(avg, Ordering::Relaxed);
                     }
@@ -559,14 +601,14 @@ pub mod hardware {
 
         /// Set speed in steps-per-second; worker thread reads this atomically.
         pub fn set_speed_sps(&mut self, sps: u32) {
-            self.sps.store(sps, Ordering::Relaxed);
+            self.sps.store(sps, Ordering::Release);
         }
     }
 
     impl Drop for HardwareMotor {
         fn drop(&mut self) {
             let _ = self.shutdown_tx.send(());
-            self.running.store(false, Ordering::Relaxed);
+            self.running.store(false, Ordering::Release);
             if let Some(h) = self.handle.take() {
                 let _ = h.join();
             }
@@ -579,7 +621,7 @@ pub mod hardware {
         fn start(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
             self.set_enabled(true)
                 .map_err(|e| Box::<dyn Error + Send + Sync>::from(e))?;
-            self.running.store(true, Ordering::Relaxed);
+            self.running.store(true, Ordering::Release);
             info!("motor started");
             Ok(())
         }
@@ -594,7 +636,7 @@ pub mod hardware {
         }
 
         fn stop(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
-            self.running.store(false, Ordering::Relaxed);
+            self.running.store(false, Ordering::Release);
             self.set_speed_sps(0);
             info!("motor stopped");
             Ok(())
@@ -612,50 +654,6 @@ pub mod hardware {
     #[inline(always)]
     fn spin_delay_min() {
         std::hint::spin_loop();
-    }
-
-    /// Busy-wait for at least ~1 microsecond to cleanly separate edges.
-    #[inline(always)]
-    fn busy_wait_min_1us() {
-        // Calibrate a rough spin count for ~1µs once per process, then spin that many times.
-        // This avoids relying on a fixed number of spin_loop() calls which varies by CPU.
-        #[inline]
-        fn spins_per_us() -> u32 {
-            use std::sync::OnceLock;
-            static SPINS: OnceLock<u32> = OnceLock::new();
-            *SPINS.get_or_init(|| {
-                use std::time::{Duration, Instant};
-                // Try increasing iteration counts until we measure ≥ 100µs to reduce timer noise.
-                let mut iters: u32 = 1_000;
-                let mut per_us: u32 = 2; // conservative fallback
-                for _ in 0..10 {
-                    let start = Instant::now();
-                    // Volatile loop to prevent unrolling/elimination
-                    let mut i = 0u32;
-                    while i < iters {
-                        std::hint::spin_loop();
-                        i = i.wrapping_add(1);
-                    }
-                    let dt = start.elapsed();
-                    if dt >= Duration::from_micros(100) {
-                        // per_us ≈ iters / elapsed_us
-                        let us = dt.as_micros().max(1) as u64;
-                        per_us = ((iters as u64 + us - 1) / us).clamp(1, 1_000_000) as u32;
-                        break;
-                    }
-                    // Increase work and try again
-                    iters = iters.saturating_mul(4).min(4_000_000);
-                }
-                per_us.max(1)
-            })
-        }
-
-        let n = spins_per_us();
-        let mut i = 0u32;
-        while i < n {
-            std::hint::spin_loop();
-            i = i.wrapping_add(1);
-        }
     }
 
     #[cfg(all(feature = "rt", target_os = "linux"))]
@@ -690,6 +688,7 @@ pub mod hardware {
         active_low: bool,
         poll_ms: u64,
     ) -> HwResult<Box<dyn Fn() -> bool + Send + Sync>> {
+        use std::sync::Weak;
         use std::sync::atomic::AtomicBool;
         let gpio = Gpio::new().map_err(|e| HwError::Gpio(format!("open GPIO: {e}")))?;
         let pin = gpio
@@ -697,23 +696,31 @@ pub mod hardware {
             .map_err(|e| HwError::Gpio(format!("get E-STOP pin: {e}")))?
             .into_input();
         let flag = Arc::new(AtomicBool::new(false));
-        let flag_bg = flag.clone();
+        // The polling thread holds only a Weak ref, so it terminates (releasing the
+        // GPIO claim, no thread leak) as soon as the returned checker closure — the
+        // sole strong owner — is dropped at the end of a dose.
+        let flag_weak: Weak<AtomicBool> = Arc::downgrade(&flag);
         thread::spawn(move || {
             let clock = MonotonicClock::new();
             loop {
+                let Some(flag) = flag_weak.upgrade() else {
+                    break;
+                };
                 let level_low = pin.read() == rppal::gpio::Level::Low;
                 let active = if active_low { level_low } else { !level_low };
-                flag_bg.store(active, Ordering::Relaxed);
+                flag.store(active, Ordering::Release);
+                drop(flag); // release the strong ref before sleeping
                 clock.sleep(Duration::from_millis(poll_ms.max(1)));
             }
+            tracing::trace!("E-stop checker thread exiting (checker dropped)");
         });
-        Ok(Box::new(move || flag.load(Ordering::Relaxed)))
+        Ok(Box::new(move || flag.load(Ordering::Acquire)))
     }
 }
 
 // Re-exports for callers (CLI/tests) to pick the right backend easily.
 #[cfg(any(not(feature = "hardware"), not(target_os = "linux")))]
-pub use sim::{SimulatedMotor, SimulatedScale};
+pub use sim::{SimulatedMotor, SimulatedScale, sim_pair};
 
 #[cfg(all(feature = "hardware", target_os = "linux"))]
 pub use hardware::{HardwareMotor, HardwareScale, make_estop_checker};

--- a/doser_hardware/src/util.rs
+++ b/doser_hardware/src/util.rs
@@ -3,6 +3,53 @@ use std::time::Duration;
 use crate::error::{HwError, Result};
 use doser_traits::clock::Clock;
 
+/// Busy-wait for at least ~1 microsecond to cleanly separate GPIO edges.
+///
+/// Used for HX711 SCK pulse timing (datasheet minimum high/low ~0.2µs) and motor
+/// STEP edges. A single `spin_loop()` hint can be only a few nanoseconds — well
+/// below the device minimum on a fast Pi — so we calibrate a rough spin count for
+/// ~1µs once per process and spin that many times. 1µs is comfortably above the
+/// minimum and well below the HX711's ~50µs power-down threshold.
+#[inline]
+pub fn busy_wait_min_1us() {
+    #[inline]
+    fn spins_per_us() -> u32 {
+        use std::sync::OnceLock;
+        use std::time::Instant;
+        static SPINS: OnceLock<u32> = OnceLock::new();
+        *SPINS.get_or_init(|| {
+            // Increase iteration counts until we measure ≥ 100µs to reduce timer noise.
+            let mut iters: u32 = 1_000;
+            let mut per_us: u32 = 2; // conservative fallback
+            for _ in 0..10 {
+                let start = Instant::now();
+                let mut i = 0u32;
+                while i < iters {
+                    std::hint::spin_loop();
+                    i = i.wrapping_add(1);
+                }
+                let dt = start.elapsed();
+                if dt >= Duration::from_micros(100) {
+                    let us = u64::try_from(dt.as_micros().max(1)).unwrap_or(u64::MAX);
+                    per_us = u32::try_from(u64::from(iters).div_ceil(us))
+                        .unwrap_or(u32::MAX)
+                        .clamp(1, 1_000_000);
+                    break;
+                }
+                iters = iters.saturating_mul(4).min(4_000_000);
+            }
+            per_us.max(1)
+        })
+    }
+
+    let n = spins_per_us();
+    let mut i = 0u32;
+    while i < n {
+        std::hint::spin_loop();
+        i = i.wrapping_add(1);
+    }
+}
+
 /// Wait until the provided `is_high` predicate becomes false (i.e., line goes low),
 /// or a timeout expires. Sleeps in small intervals to avoid CPU spinning.
 pub fn wait_until_low_with_timeout(

--- a/doser_traits/src/lib.rs
+++ b/doser_traits/src/lib.rs
@@ -7,7 +7,10 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 //! Traits that define the hardware and time abstractions used by the system.
 //!
-//! - `Scale` provides a blocking `read(timeout)` API that returns mass in centigrams (i32).
+//! - `Scale` provides a blocking `read(timeout)` API that returns a raw ADC
+//!   reading in counts (i32). Calibration in `doser_core` converts counts to
+//!   grams/centigrams. (The simulation backend happens to use a 1 count = 0.01 g
+//!   scale, so its raw counts equal centigrams, but that is not part of the contract.)
 //! - `Motor` configures/starts/stops motor stepping at steps-per-second.
 //! - `clock` offers a `MonotonicClock` for deterministic timing and testability.
 //!
@@ -18,6 +21,7 @@ pub mod clock;
 pub use clock::{Clock, MonotonicClock};
 
 pub trait Scale {
+    /// Read one raw ADC sample in counts, blocking up to `timeout`.
     fn read(
         &mut self,
         timeout: std::time::Duration,

--- a/examples/custom_strategy.rs
+++ b/examples/custom_strategy.rs
@@ -4,12 +4,14 @@
 //! enabling custom logic between iterations (logging, dynamic speed changes, etc.).
 
 use doser_core::{Doser, DosingStatus};
-use doser_hardware::{SimulatedMotor, SimulatedScale};
+use doser_hardware::sim_pair;
 
 fn main() -> eyre::Result<()> {
+    // Linked sim pair so the scale's reading responds to the motor running.
+    let (scale, motor) = sim_pair();
     let mut doser = Doser::builder()
-        .with_scale(SimulatedScale::new())
-        .with_motor(SimulatedMotor::default())
+        .with_scale(scale)
+        .with_motor(motor)
         .with_target_grams(5.0)
         .build()?;
 

--- a/examples/quick_start.rs
+++ b/examples/quick_start.rs
@@ -3,7 +3,7 @@
 //! This example demonstrates how to set up and run a simulated dosing session using the Doser library.
 
 use doser_core::{ControlCfg, Doser, DosingStatus, FilterCfg, Timeouts};
-use doser_hardware::{SimulatedMotor as SimMotor, SimulatedScale as SimScale};
+use doser_hardware::sim_pair;
 use doser_traits::MonotonicClock;
 use std::time::Duration;
 
@@ -35,10 +35,11 @@ fn main() -> Result<(), eyre::Report> {
     // Local monotonic clock for timing in this example
     let clock = MonotonicClock::new();
 
-    // Build a Doser with simulated hardware and pass a clock into the builder
+    // Build a Doser with a linked simulated scale/motor pair and a clock
+    let (scale, motor) = sim_pair();
     let mut doser = Doser::builder()
-        .with_scale(SimScale::default())
-        .with_motor(SimMotor::default())
+        .with_scale(scale)
+        .with_motor(motor)
         .with_filter(FilterCfg::default())
         .with_control(ControlCfg::default())
         .with_timeouts(Timeouts { sensor_ms: 10 })

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,70 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# Doser installer.
+#
+# Safety:
+# - Runs with `set -euo pipefail` so any failed step aborts the install.
+# - Verifies the downloaded binary against an expected SHA-256 checksum when one
+#   is provided (strongly recommended). Set DOSER_SHA256, or place a checksum in
+#   ${BASE_URL}/doser_cli.sha256 alongside the binary.
+# - Downloads to a temp file and only installs it after verification.
+set -euo pipefail
 
-# Download binary and config files (replace URLs with your actual release locations)
-curl -L https://yourdomain.com/releases/doser_cli -o /usr/local/bin/doser_cli
-curl -L https://yourdomain.com/releases/doser_config.toml -o /etc/doser_config.toml
-curl -L https://yourdomain.com/releases/doser_config.csv -o /etc/doser_config.csv
+# Configurable download location (override via env). Replace with your real host.
+BASE_URL="${DOSER_BASE_URL:-https://yourdomain.com/releases}"
+BIN_DEST="${DOSER_BIN_DEST:-/usr/local/bin/doser_cli}"
+CONF_DEST="${DOSER_CONF_DEST:-/etc/doser_config.toml}"
+CSV_DEST="${DOSER_CSV_DEST:-/etc/doser_config.csv}"
 
-# Make binary executable
-chmod +x /usr/local/bin/doser_cli
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
+echo "Downloading doser_cli from ${BASE_URL} ..."
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/doser_cli" -o "${tmpdir}/doser_cli"
+
+# Verify checksum. Prefer an explicit DOSER_SHA256; otherwise try a published
+# .sha256 file. Abort if neither is available — installing unverified binaries
+# that drive hardware is unsafe.
+expected_sha="${DOSER_SHA256:-}"
+if [ -z "${expected_sha}" ]; then
+	if curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/doser_cli.sha256" -o "${tmpdir}/doser_cli.sha256" 2>/dev/null; then
+		expected_sha="$(awk '{print $1}' "${tmpdir}/doser_cli.sha256")"
+	fi
+fi
+
+if [ -z "${expected_sha}" ]; then
+	echo "ERROR: no checksum available (set DOSER_SHA256 or publish doser_cli.sha256). Refusing to install unverified binary." >&2
+	exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual_sha="$(sha256sum "${tmpdir}/doser_cli" | awk '{print $1}')"
+else
+	actual_sha="$(shasum -a 256 "${tmpdir}/doser_cli" | awk '{print $1}')"
+fi
+
+if [ "${actual_sha}" != "${expected_sha}" ]; then
+	echo "ERROR: checksum mismatch for doser_cli" >&2
+	echo "  expected: ${expected_sha}" >&2
+	echo "  actual:   ${actual_sha}" >&2
+	exit 1
+fi
+echo "Checksum OK."
+
+# Install binary (atomic move into place) and make it executable.
+sudo install -m 0755 "${tmpdir}/doser_cli" "${BIN_DEST}"
+
+# Download config files (do not overwrite existing local edits without asking).
+for pair in "doser_config.toml:${CONF_DEST}" "doser_config.csv:${CSV_DEST}"; do
+	name="${pair%%:*}"
+	dest="${pair##*:}"
+	if [ -e "${dest}" ]; then
+		echo "Keeping existing ${dest} (remove it to refresh)."
+		continue
+	fi
+	curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/${name}" -o "${tmpdir}/${name}"
+	sudo install -m 0644 "${tmpdir}/${name}" "${dest}"
+done
 
 # Create service user if missing (system user with no shell)
 if ! id -u doser >/dev/null 2>&1; then
@@ -35,7 +92,7 @@ cat <<'EOF' | sudo tee /etc/logrotate.d/doser >/dev/null
 EOF
 
 # Optionally create a systemd service for auto-start
-cat <<EOF | sudo tee /etc/systemd/system/doser.service
+cat <<EOF | sudo tee /etc/systemd/system/doser.service >/dev/null
 [Unit]
 Description=Bean Doser Service
 After=network.target
@@ -45,7 +102,7 @@ User=doser
 Group=doser
 WorkingDirectory=/var/lib/doser
 Environment=RUST_LOG=info
-ExecStart=/usr/local/bin/doser_cli --config /etc/doser_config.toml --calibration /etc/doser_config.csv
+ExecStart=${BIN_DEST} --config ${CONF_DEST} --calibration ${CSV_DEST}
 Restart=always
 RestartSec=1s
 # Write logs to dedicated files under /var/log/doser

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
+# Pinned to an exact version for reproducible builds. Bump deliberately.
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Implements the verified findings from a deep multi-dimensional audit.

Correctness/precision:
- Fix calibration gain quantization: gain was stored as integer centigrams-per-count, collapsing realistic load-cell gains (~5e-4 g/count) to zero. Now a scaled integer (fixed_point::GAIN_SCALE) preserving sub-count resolution with deterministic i128 math.
- Preserve persisted calibration offset_g end-to-end (was silently dropped).

Safety:
- Honor Ctrl-C/shutdown in the default (non-stats) runner path.
- Best-effort motor stop with retry + error-level escalation on abort paths.
- Out-of-band E-stop poll in sampler mode (decouple latency from sensor reads).
- E-stop GPIO checker thread self-terminates via Weak (no leak).
- Calibrated ~1us HX711 SCK busy-wait (was a no-op spin_loop).

Concurrency/security:
- Release/Acquire on stall-watchdog timestamp and motor running/speed flags.
- Replace global sim statics with per-instance state + sim_pair().
- Reject non-finite config floats; cap filter/predictor windows; bound config file and calibration CSV sizes.

Feature/perf/supply chain:
- Implement control.hysteresis_g settle band (was parsed but unused).
- O(n) median via select_nth_unstable.
- Pin toolchain (1.96.0) and cross; checksum-verify install.sh; fix release binary name (doser_cli) + ship .sha256; test default features in CI.

Tests: assert motor stops on every abort reason; offset_g round-trip; small-gain calibration accuracy; hysteresis reset; NaN/oversized-window config rejection.