### PR TITLE
Fix sampler shutdown deadlock: non-blocking publish

### DIFF
--- a/doser_core/src/sampler.rs
+++ b/doser_core/src/sampler.rs
@@ -48,14 +48,23 @@ impl Sampler {
 
                 match scale.read(timeout) {
                     Ok(v) => {
-                        // If send fails, consumer is gone; exit gracefully
-                        if tx.send(v).is_err() {
-                            tracing::debug!("Sampler consumer disconnected, exiting thread");
-                            break;
-                        }
                         let now = clock.ms_since(epoch);
                         // Release so the watchdog reader (Acquire) observes a fresh timestamp.
+                        // Mark liveness on a successful read, independent of delivery.
                         last_ok_clone.store(now, Ordering::Release);
+                        // Non-blocking publish (latest-value, best effort). A blocking send
+                        // on the bounded(1) channel could deadlock the Drop join if the
+                        // consumer stops while the channel is full, so never block here.
+                        match tx.try_send(v) {
+                            Ok(()) => {}
+                            Err(xch::TrySendError::Full(_)) => {
+                                // Consumer is behind; drop this sample.
+                            }
+                            Err(xch::TrySendError::Disconnected(_)) => {
+                                tracing::debug!("Sampler consumer disconnected, exiting thread");
+                                break;
+                            }
+                        }
                     }
                     Err(_) => {
                         // Optional: send special value or skip; controller has watchdog
@@ -104,14 +113,25 @@ impl Sampler {
 
                 match scale.read(timeout) {
                     Ok(v) => {
-                        // If send fails, consumer is gone; exit gracefully
-                        if tx.send(v).is_err() {
-                            tracing::debug!("Sampler event consumer disconnected, exiting thread");
-                            break;
-                        }
                         let now = clock.ms_since(epoch);
                         // Release so the watchdog reader (Acquire) observes a fresh timestamp.
+                        // Mark liveness on a successful read, independent of delivery.
                         last_ok_clone.store(now, Ordering::Release);
+                        // Non-blocking publish (latest-value, best effort): never block on a
+                        // full channel, so the thread always observes shutdown and the Drop
+                        // join cannot deadlock.
+                        match tx.try_send(v) {
+                            Ok(()) => {}
+                            Err(xch::TrySendError::Full(_)) => {
+                                // Consumer is behind; drop this sample.
+                            }
+                            Err(xch::TrySendError::Disconnected(_)) => {
+                                tracing::debug!(
+                                    "Sampler event consumer disconnected, exiting thread"
+                                );
+                                break;
+                            }
+                        }
                     }
                     Err(_) => {
                         // On timeout or transient error, just continue; controller will watchdog

--- a/doser_core/tests/sampler_thread_lifecycle.rs
+++ b/doser_core/tests/sampler_thread_lifecycle.rs
@@ -113,6 +113,37 @@ fn sampler_can_be_created_dropped_and_recreated() {
 }
 
 #[test]
+fn sampler_drop_is_prompt_with_full_channel() {
+    // The other tests use NoopScale (always errors), so the bounded channel never
+    // fills. Here the scale always succeeds and the consumer never reads, so the
+    // channel stays full: a blocking send would deadlock Drop's join. The drop runs
+    // on a worker thread so a hang fails the test (timeout) instead of hanging the
+    // whole suite.
+    struct AlwaysOk;
+    impl doser_traits::Scale for AlwaysOk {
+        fn read(&mut self, _t: Duration) -> Result<i32, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(42)
+        }
+    }
+
+    let clock = MonotonicClock::new();
+    let sampler = Sampler::spawn(AlwaysOk, 1000, Duration::from_millis(10), clock);
+    // Let the producer fill the channel; deliberately never consume.
+    std::thread::sleep(Duration::from_millis(50));
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        drop(sampler);
+        let _ = tx.send(());
+    });
+    assert!(
+        rx.recv_timeout(Duration::from_secs(3)).is_ok(),
+        "Sampler drop deadlocked with a full channel"
+    );
+    let _ = handle.join();
+}
+
+#[test]
 fn sampler_shutdown_is_prompt() {
     // For a dosing system, shutdown must be fast to ensure safety
     let clock = MonotonicClock::new();


### PR DESCRIPTION
The sampler thread used a blocking `tx.send` on a bounded(1) channel. If the channel was full at the moment the consumer stopped (a race at dose completion, since the consumer drains then returns Complete), the thread blocked in `send`, never observed the shutdown flag, and `Sampler::drop`'s join() hung indefinitely — not bounded by max_run, so a sampler-mode run could appear to hang forever.

Publish with `try_send` (latest-value, best effort) and mark watchdog liveness on a successful read rather than a successful send, so the thread never blocks and always observes shutdown. Add a regression test that fills the channel and never consumes, asserting Drop completes promptly (the prior NoopScale-based tests never produced a value, so they could not exercise this path).