### PR TITLE
Fix HX711 gain-pulse count: 49 SCK pulses per read -> correct 25

### DIFF
--- a/doser_hardware/src/hx711.rs
+++ b/doser_hardware/src/hx711.rs
@@ -8,7 +8,10 @@ use doser_traits::clock::MonotonicClock;
 pub struct Hx711 {
     dt: rppal::gpio::InputPin,
     sck: rppal::gpio::OutputPin,
-    gain_pulses: u8, // 25, 26, 27 based on gain/channel
+    // Extra SCK pulses sent after the 24 data bits; they select the next
+    // conversion's gain/channel: 1 = ch A/gain 128, 2 = ch B/gain 32,
+    // 3 = ch A/gain 64 (i.e. 25, 26, or 27 total pulses per read).
+    gain_pulses: u8,
     data_ready_timeout: Duration,
 }
 
@@ -56,7 +59,9 @@ impl Hx711 {
             busy_wait_min_1us();
         }
 
-        // Pulse gain to set next measurement
+        // Send the extra gain/channel pulses. Combined with the 24 data pulses
+        // above this gives 24 + gain_pulses = 25/26/27 total, selecting the
+        // gain/channel for the next conversion.
         for _ in 0..self.gain_pulses {
             self.sck.set_high();
             busy_wait_min_1us();

--- a/doser_hardware/src/lib.rs
+++ b/doser_hardware/src/lib.rs
@@ -422,8 +422,8 @@ pub mod hardware {
                 .get(sck_pin)
                 .map_err(|e| HwError::Gpio(format!("get HX711 SCK pin: {e}")))?
                 .into_output_low();
-            // Channel A, gain = 128 uses 25 pulses after the 24-bit read.
-            let hx = Hx711::new(dt, sck, 25, Duration::from_millis(150))?;
+            // Channel A / gain 128: 1 extra SCK pulse after the 24 data bits (25 total).
+            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(150))?;
             Ok(Self { hx })
         }
 
@@ -448,7 +448,8 @@ pub mod hardware {
             } else {
                 data_ready_timeout_ms
             };
-            let hx = Hx711::new(dt, sck, 25, Duration::from_millis(drt))?;
+            // Channel A / gain 128: 1 extra SCK pulse after the 24 data bits (25 total).
+            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(drt))?;
             Ok(Self { hx })
         }
 


### PR DESCRIPTION
read_with_timeout() clocks out 24 data bits and then `gain_pulses` extra pulses. Both HardwareScale constructors passed gain_pulses=25, giving 24 + 25 = 49 total SCK pulses — out of the HX711's 25/26/27 spec, which causes wrong/erratic readings on real hardware. For Channel A / gain 128 the total must be 25, i.e. 1 extra pulse after the 24 data bits. Pass 1 at both call sites and document gain_pulses as the number of EXTRA pulses (1/2/3 -> 25/26/27 total = ch A g128 / ch B g32 / ch A g64).

Intended gain stays 128 (Channel A); data-ready timeouts unchanged.