### PR TITLE
ci: gate on release-profile clippy, and keep the action pins fresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot keeps the SHA-pinned GitHub Actions current.
+#
+# The workflows pin every action to a full commit SHA rather than a movable tag,
+# because a force-moved tag would run attacker code with the workflow's
+# GITHUB_TOKEN. That closes the hijack vector but freezes the versions: a SHA
+# never updates itself, so without this file the repo would quietly sit on stale
+# actions — including ones whose runtime GitHub later deprecates, which is
+# exactly how `rustsec/audit-check` and `softprops/action-gh-release` ended up
+# stranded on node16.
+#
+# Dependabot understands the `# vN` trailing comments and updates the SHA and
+# the comment together, so the pins stay both current and legible.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+    groups:
+      # One PR per week for routine bumps rather than one per action. Major
+      # bumps stay separate: they can carry breaking input changes and deserve
+      # to be reviewed on their own (see the v1 -> v2 migrations in #25).
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
         run: cargo fmt --all -- --check
       - name: cargo clippy (workspace, all targets, deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: cargo clippy (release profile)
+        # Not redundant with the debug run above. Every crate carries
+        #   #![cfg_attr(all(not(debug_assertions), not(test)),
+        #                deny(clippy::all, clippy::pedantic, clippy::nursery))]
+        # so the release profile lints a strictly larger set, and CI only ever
+        # ran the debug profile. That gap let 321 errors accumulate unnoticed:
+        # compilation died in doser_traits, so the four crates downstream of it
+        # had never been release-linted at all.
+        run: cargo clippy --release --workspace --all-targets -- -D warnings
       - name: cargo check (workspace, all targets)
         env:
           RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
   # `checks` is the single owner of fmt + clippy for the whole workflow.
   # Do not re-add those steps to other jobs: every job is a cold build on a
   # fresh runner, so duplicating them just multiplies CI time.
+  #
+  # ONE deliberate exception: the feature-gated release clippy lives in
+  # `test-hardware-feature`, because it needs a different feature set than
+  # anything here and that job already pays for a hardware-feature build. It is
+  # not a duplicate of the clippy steps below — see the comment on that step for
+  # why default-feature clippy cannot see that code. Do not "de-duplicate" it.
   checks:
     name: checks
     runs-on: ubuntu-latest
@@ -113,6 +119,30 @@ jobs:
         run: |
           cargo build -p doser_hardware --features hardware --no-default-features
           cargo build -p doser_cli --features hardware --no-default-features
+      - name: cargo clippy (release profile, hardware + rt features)
+        # Third instance of the same blind spot. The release-profile clippy in
+        # `checks` runs with DEFAULT features, and default is `hardware = off,
+        # rt = off`. Everything inside
+        #   #[cfg(all(feature = "hardware", target_os = "linux"))]   (HX711 driver,
+        #                                                             HardwareMotor)
+        #   #[cfg(all(feature = "rt",       target_os = "linux"))]   (clock_nanosleep
+        #                                                             pacing, SCHED_FIFO)
+        # is therefore never even parsed by that step, so the crate-level
+        # deny(clippy::all, pedantic, nursery) never sees it. That is exactly how 10
+        # errors accumulated in doser_hardware while CI stayed green — the same way
+        # 321 accumulated before the release step existed at all.
+        #
+        # `doser_cli/hardware` and `doser_cli/rt` forward to the matching
+        # `doser_hardware` features, so this single invocation enables the union of
+        # both cfgs — including the `#[cfg(feature = "rt")]` RT-elevation call nested
+        # inside the hardware-only stepping thread, which needs BOTH features to
+        # compile. No --target is needed: this runner is already linux, which is what
+        # satisfies the target_os = "linux" half of every cfg above.
+        #
+        # This does NOT replace the default-feature clippy in `checks`: with
+        # `hardware` on, the simulation backends are cfg'd out. The two runs are
+        # complementary and both are required to cover the crate.
+        run: cargo clippy --release --workspace --all-targets --features doser_cli/hardware,doser_cli/rt -- -D warnings
 
   # Informational only. This job publishes a coverage number for the owner to
   # look at; it enforces no threshold and gates nothing. It is deliberately

--- a/doser_cli/src/dose.rs
+++ b/doser_cli/src/dose.rs
@@ -22,7 +22,7 @@ pub const fn abort_reason_name(r: &doser_core::error::AbortReason) -> &'static s
 fn make_estop_check(cfg: &doser_config::Config) -> Option<Box<dyn Fn() -> bool + Send + Sync>> {
     #[cfg(all(feature = "hardware", target_os = "linux"))]
     {
-        if let Some(pin) = cfg.pins.estop_in {
+        cfg.pins.estop_in.and_then(|pin| {
             match doser_hardware::make_estop_checker(pin, cfg.estop.active_low, cfg.estop.poll_ms) {
                 Ok(c) => {
                     tracing::info!(
@@ -38,9 +38,7 @@ fn make_estop_check(cfg: &doser_config::Config) -> Option<Box<dyn Fn() -> bool +
                     None
                 }
             }
-        } else {
-            None
-        }
+        })
     }
     #[cfg(not(all(feature = "hardware", target_os = "linux")))]
     {

--- a/doser_cli/src/main.rs
+++ b/doser_cli/src/main.rs
@@ -292,7 +292,7 @@ fn cmd_self_check<S: doser_traits::Scale>(scale: S, cfg: &Config) -> eyre::Resul
                 let param = sched_param {
                     sched_priority: req,
                 };
-                let rc = sched_setscheduler(0, SCHED_FIFO, &param);
+                let rc = sched_setscheduler(0, SCHED_FIFO, &raw const param);
                 if rc != 0 {
                     let err = std::io::Error::last_os_error();
                     let code = err.raw_os_error().unwrap_or(0);

--- a/doser_cli/src/rt.rs
+++ b/doser_cli/src/rt.rs
@@ -3,226 +3,250 @@
 use crate::cli::RtLock;
 
 #[cfg(target_os = "linux")]
-/// Capacity of cpu_set_t in CPU indices (bits).
+use std::sync::OnceLock;
+
+#[cfg(target_os = "linux")]
+/// Capacity of `cpu_set_t` in CPU indices (bits).
 const MAX_CPUSET_BITS: usize = std::mem::size_of::<libc::cpu_set_t>() * 8;
+
+/// `CAP_SYS_NICE` (capability 23) as a bit in the `/proc/self/status` capability masks.
+#[cfg(target_os = "linux")]
+const CAP_SYS_NICE_BIT: u64 = 0x0080_0000;
+
+// Apply process memory locking according to the selected mode.
+#[cfg(target_os = "linux")]
+#[inline]
+fn try_apply_mem_lock(lock: RtLock) -> eyre::Result<()> {
+    #[inline]
+    fn is_retryable_memlock_error(err: &std::io::Error) -> bool {
+        matches!(err.raw_os_error(), Some(code) if code == libc::EPERM || code == libc::ENOMEM)
+    }
+    use libc::{MCL_CURRENT, MCL_FUTURE, mlockall};
+    use std::fmt::Write as _;
+
+    #[inline]
+    fn memlock_limit_hint() -> Option<String> {
+        unsafe {
+            let mut rlim = std::mem::MaybeUninit::<libc::rlimit>::uninit();
+            let rc = libc::getrlimit(libc::RLIMIT_MEMLOCK, rlim.as_mut_ptr());
+            if rc == 0 {
+                let r = rlim.assume_init();
+                let cur = r.rlim_cur;
+                if cur == libc::RLIM_INFINITY {
+                    Some("memlock limit: unlimited".to_string())
+                } else {
+                    Some(format!("memlock limit: {} KiB", cur / 1024))
+                }
+            } else {
+                None
+            }
+        }
+    }
+
+    #[inline]
+    fn lock_current() -> std::io::Result<()> {
+        let rc = unsafe { mlockall(MCL_CURRENT) };
+        if rc != 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn lock_all() -> std::io::Result<()> {
+        let rc = unsafe { mlockall(MCL_CURRENT | MCL_FUTURE) };
+        if rc != 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    let attempted_all = matches!(lock, RtLock::All);
+    let result: std::io::Result<()> = match lock {
+        RtLock::None => Ok(()),
+        RtLock::Current => lock_current(),
+        RtLock::All => lock_all(),
+    };
+    if result.is_ok() {
+        return Ok(());
+    }
+    let err = result
+        .err()
+        .unwrap_or_else(|| std::io::Error::other("mlockall failed"));
+
+    // Fallback: if All failed due to permission or memory, try Current
+    let mut fallback_err: Option<std::io::Error> = None;
+    if attempted_all && is_retryable_memlock_error(&err) {
+        match lock_current() {
+            Ok(()) => return Ok(()),
+            Err(e2) => fallback_err = Some(e2),
+        }
+    }
+
+    let mut msg = format!(
+        "mlockall({}) failed: {}",
+        if attempted_all {
+            "current|future"
+        } else {
+            "current"
+        },
+        err
+    );
+    if is_retryable_memlock_error(&err) {
+        // Writing to a String is infallible, so the formatting result is discarded.
+        if let Some(h) = memlock_limit_hint() {
+            let _ = write!(msg, "; {h}");
+        }
+        msg.push_str("; hint: needs CAP_IPC_LOCK (or root) and sufficient 'ulimit -l'");
+        if let Some(e2) = fallback_err {
+            let _ = write!(msg, "; fallback mlockall(current) also failed: {e2}");
+        }
+    }
+    Err(eyre::eyre!(msg))
+}
+
+// Apply SCHED_FIFO priority, clamped to the system range.
+#[cfg(target_os = "linux")]
+#[inline]
+fn try_apply_fifo_priority(prio: Option<i32>) -> eyre::Result<()> {
+    use libc::{
+        SCHED_FIFO, sched_get_priority_max, sched_get_priority_min, sched_param, sched_setscheduler,
+    };
+
+    {
+        use std::fs;
+        if let Ok(status) = fs::read_to_string("/proc/self/status") {
+            let has_cap = status.lines().any(|line| {
+                if (line.starts_with("CapEff:") || line.starts_with("CapPrm:"))
+                    && let Some(hex) = line.split_whitespace().nth(1)
+                    && let Ok(caps) = u64::from_str_radix(hex, 16)
+                {
+                    return caps & CAP_SYS_NICE_BIT != 0;
+                }
+                false
+            });
+
+            if !has_cap {
+                let is_root = unsafe { libc::geteuid() == 0 };
+                if !is_root {
+                    return Err(eyre::eyre!(
+                        "Insufficient privileges for SCHED_FIFO: needs CAP_SYS_NICE or root. \
+                            Current effective UID: {}. \
+                            Hint: Run with 'sudo' or grant CAP_SYS_NICE: 'sudo setcap cap_sys_nice=ep /path/to/doser'",
+                        unsafe { libc::geteuid() }
+                    ));
+                }
+            }
+        }
+    }
+
+    let (min, max) = unsafe {
+        let min = sched_get_priority_min(SCHED_FIFO);
+        let max = sched_get_priority_max(SCHED_FIFO);
+        if min < 0 || max < 0 {
+            (1, 99)
+        } else {
+            (min, max)
+        }
+    };
+    let wanted = prio.unwrap_or(max);
+    let prio_val = wanted.clamp(min, max);
+    let param = sched_param {
+        sched_priority: prio_val,
+    };
+    // `sched_setscheduler` takes a `*const sched_param`.
+    let rc = unsafe { sched_setscheduler(0, SCHED_FIFO, &raw const param) };
+    if rc != 0 {
+        Err(eyre::eyre!(std::io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+// Pin process to a single CPU if permitted by the current affinity mask.
+#[cfg(target_os = "linux")]
+#[inline]
+fn try_apply_affinity(
+    rt_cpu: Option<usize>,
+    online_cpus: &OnceLock<libc::c_long>,
+    mask: &OnceLock<libc::cpu_set_t>,
+) -> eyre::Result<()> {
+    use libc::{CPU_ISSET, CPU_SET, CPU_ZERO};
+
+    let _ = online_cpus.get_or_init(|| unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) });
+    let _ = mask.get_or_init(|| {
+        let mut set: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        unsafe { CPU_ZERO(&mut set) };
+        // `sched_getaffinity` writes through a `*mut cpu_set_t`.
+        let rc = unsafe {
+            libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &raw mut set)
+        };
+        if rc != 0 {
+            unsafe { CPU_ZERO(&mut set) };
+            let n = online_cpus
+                .get()
+                .copied()
+                .unwrap_or_else(|| unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) });
+            // A negative sysconf return (query failed) means "no CPUs known" -> 0.
+            let n = usize::try_from(n).unwrap_or(0);
+            let n = n.min(MAX_CPUSET_BITS);
+            for i in 0..n {
+                unsafe { CPU_SET(i, &mut set) };
+            }
+        }
+        set
+    });
+    let nprocs_onln = *online_cpus.get().unwrap_or(&0);
+    if nprocs_onln < 1 {
+        eyre::bail!("_SC_NPROCESSORS_ONLN < 1");
+    }
+    let target = rt_cpu.unwrap_or(0);
+    // A `target` that does not fit in a c_long cannot be below the online count either; it
+    // falls through to the cpu_set_t capacity check below, exactly as the previous
+    // `target as c_long` comparison did (the cast went negative and so never tripped here).
+    if libc::c_long::try_from(target).is_ok_and(|t| t >= nprocs_onln) {
+        eyre::bail!("requested CPU {target} >= online {nprocs_onln}");
+    }
+    if target >= MAX_CPUSET_BITS {
+        eyre::bail!("requested CPU {target} exceeds cpu_set_t capacity {MAX_CPUSET_BITS}");
+    }
+    let Some(allowed) = mask.get() else {
+        eyre::bail!("cpuset init failed");
+    };
+    let allowed_target = unsafe { CPU_ISSET(target, allowed) };
+    if !allowed_target {
+        eyre::bail!("CPU {target} not permitted by current affinity mask");
+    }
+    let mut desired: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+    unsafe {
+        CPU_ZERO(&mut desired);
+        CPU_SET(target, &mut desired);
+    }
+    // `sched_setaffinity` only reads the mask: `*const cpu_set_t`.
+    let rc = unsafe {
+        libc::sched_setaffinity(
+            0,
+            std::mem::size_of::<libc::cpu_set_t>(),
+            &raw const desired,
+        )
+    };
+    if rc != 0 {
+        Err(eyre::eyre!(std::io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
 
 #[cfg(target_os = "linux")]
 pub fn setup_rt_once(rt: bool, prio: Option<i32>, lock: RtLock, rt_cpu: Option<usize>) {
-    use libc::{
-        CPU_ISSET, CPU_SET, CPU_ZERO, SCHED_FIFO, sched_get_priority_max, sched_get_priority_min,
-        sched_param, sched_setscheduler,
-    };
-    use std::sync::OnceLock;
     static RT_ONCE: OnceLock<()> = OnceLock::new();
     static ONLINE_CPUS: OnceLock<libc::c_long> = OnceLock::new();
     static CPUSET: OnceLock<libc::cpu_set_t> = OnceLock::new();
 
     if !rt {
         return;
-    }
-
-    // Apply process memory locking according to the selected mode.
-    #[inline]
-    fn try_apply_mem_lock(lock: RtLock) -> eyre::Result<()> {
-        #[inline]
-        fn is_retryable_memlock_error(err: &std::io::Error) -> bool {
-            matches!(err.raw_os_error(), Some(code) if code == libc::EPERM || code == libc::ENOMEM)
-        }
-        use libc::{MCL_CURRENT, MCL_FUTURE, mlockall};
-
-        #[inline]
-        fn memlock_limit_hint() -> Option<String> {
-            unsafe {
-                let mut rlim = std::mem::MaybeUninit::<libc::rlimit>::uninit();
-                let rc = libc::getrlimit(libc::RLIMIT_MEMLOCK, rlim.as_mut_ptr());
-                if rc == 0 {
-                    let r = rlim.assume_init();
-                    let cur = r.rlim_cur;
-                    if cur == libc::RLIM_INFINITY {
-                        Some("memlock limit: unlimited".to_string())
-                    } else {
-                        Some(format!("memlock limit: {} KiB", cur / 1024))
-                    }
-                } else {
-                    None
-                }
-            }
-        }
-
-        #[inline]
-        fn lock_current() -> std::io::Result<()> {
-            let rc = unsafe { mlockall(MCL_CURRENT) };
-            if rc != 0 {
-                Err(std::io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
-        }
-
-        #[inline]
-        fn lock_all() -> std::io::Result<()> {
-            let rc = unsafe { mlockall(MCL_CURRENT | MCL_FUTURE) };
-            if rc != 0 {
-                Err(std::io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
-        }
-
-        let attempted_all = matches!(lock, RtLock::All);
-        let result: std::io::Result<()> = match lock {
-            RtLock::None => Ok(()),
-            RtLock::Current => lock_current(),
-            RtLock::All => lock_all(),
-        };
-        if result.is_ok() {
-            return Ok(());
-        }
-        let err = result
-            .err()
-            .unwrap_or_else(|| std::io::Error::other("mlockall failed"));
-
-        // Fallback: if All failed due to permission or memory, try Current
-        let mut fallback_err: Option<std::io::Error> = None;
-        if attempted_all && is_retryable_memlock_error(&err) {
-            match lock_current() {
-                Ok(()) => return Ok(()),
-                Err(e2) => fallback_err = Some(e2),
-            }
-        }
-
-        let mut msg = format!(
-            "mlockall({}) failed: {}",
-            if attempted_all {
-                "current|future"
-            } else {
-                "current"
-            },
-            err
-        );
-        if is_retryable_memlock_error(&err) {
-            if let Some(h) = memlock_limit_hint() {
-                msg.push_str(&format!("; {h}"));
-            }
-            msg.push_str("; hint: needs CAP_IPC_LOCK (or root) and sufficient 'ulimit -l'");
-            if let Some(e2) = fallback_err {
-                msg.push_str(&format!("; fallback mlockall(current) also failed: {e2}"));
-            }
-        }
-        Err(eyre::eyre!(msg))
-    }
-
-    // Apply SCHED_FIFO priority, clamped to the system range.
-    #[inline]
-    fn try_apply_fifo_priority(prio: Option<i32>) -> eyre::Result<()> {
-        #[cfg(target_os = "linux")]
-        {
-            use std::fs;
-            if let Ok(status) = fs::read_to_string("/proc/self/status") {
-                let has_cap = status.lines().any(|line| {
-                    if (line.starts_with("CapEff:") || line.starts_with("CapPrm:"))
-                        && let Some(hex) = line.split_whitespace().nth(1)
-                        && let Ok(caps) = u64::from_str_radix(hex, 16)
-                    {
-                        return caps & 0x800000 != 0;
-                    }
-                    false
-                });
-
-                if !has_cap {
-                    let is_root = unsafe { libc::geteuid() == 0 };
-                    if !is_root {
-                        return Err(eyre::eyre!(
-                            "Insufficient privileges for SCHED_FIFO: needs CAP_SYS_NICE or root. \
-                            Current effective UID: {}. \
-                            Hint: Run with 'sudo' or grant CAP_SYS_NICE: 'sudo setcap cap_sys_nice=ep /path/to/doser'",
-                            unsafe { libc::geteuid() }
-                        ));
-                    }
-                }
-            }
-        }
-
-        let (min, max) = unsafe {
-            let min = sched_get_priority_min(SCHED_FIFO);
-            let max = sched_get_priority_max(SCHED_FIFO);
-            if min < 0 || max < 0 {
-                (1, 99)
-            } else {
-                (min, max)
-            }
-        };
-        let wanted = prio.unwrap_or(max);
-        let prio_val = wanted.clamp(min, max);
-        let param = sched_param {
-            sched_priority: prio_val,
-        };
-        let rc = unsafe { sched_setscheduler(0, SCHED_FIFO, &param) };
-        if rc != 0 {
-            Err(eyre::eyre!(std::io::Error::last_os_error()))
-        } else {
-            Ok(())
-        }
-    }
-
-    // Pin process to a single CPU if permitted by the current affinity mask.
-    #[inline]
-    fn try_apply_affinity(
-        rt_cpu: Option<usize>,
-        online_cpus: &OnceLock<libc::c_long>,
-        mask: &OnceLock<libc::cpu_set_t>,
-    ) -> eyre::Result<()> {
-        let _ = online_cpus.get_or_init(|| unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) });
-        let _ = mask.get_or_init(|| {
-            let mut set: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-            unsafe { CPU_ZERO(&mut set) };
-            let rc = unsafe {
-                libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set)
-            };
-            if rc != 0 {
-                unsafe { CPU_ZERO(&mut set) };
-                let n = online_cpus
-                    .get()
-                    .copied()
-                    .unwrap_or_else(|| unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) });
-                let n = if n < 0 { 0 } else { n as usize };
-                let n = n.min(MAX_CPUSET_BITS);
-                for i in 0..n {
-                    unsafe { CPU_SET(i, &mut set) };
-                }
-            }
-            set
-        });
-        let nprocs_onln = *online_cpus.get().unwrap_or(&0);
-        if nprocs_onln < 1 {
-            eyre::bail!("_SC_NPROCESSORS_ONLN < 1");
-        }
-        let target = rt_cpu.unwrap_or(0);
-        if target as libc::c_long >= nprocs_onln {
-            eyre::bail!("requested CPU {target} >= online {nprocs_onln}");
-        }
-        if target >= MAX_CPUSET_BITS {
-            eyre::bail!("requested CPU {target} exceeds cpu_set_t capacity {MAX_CPUSET_BITS}");
-        }
-        let Some(allowed) = mask.get() else {
-            eyre::bail!("cpuset init failed");
-        };
-        let allowed_target = unsafe { (CPU_ISSET(target, allowed) as libc::c_int) != 0 };
-        if !allowed_target {
-            eyre::bail!("CPU {target} not permitted by current affinity mask");
-        }
-        let mut desired: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-        unsafe {
-            CPU_ZERO(&mut desired);
-            CPU_SET(target, &mut desired);
-        }
-        let rc =
-            unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &desired) };
-        if rc != 0 {
-            Err(eyre::eyre!(std::io::Error::last_os_error()))
-        } else {
-            Ok(())
-        }
     }
 
     RT_ONCE.get_or_init(|| {
@@ -237,9 +261,7 @@ pub fn setup_rt_once(rt: bool, prio: Option<i32>, lock: RtLock, rt_cpu: Option<u
         }
         // FIFO priority
         if let Err(err) = try_apply_fifo_priority(prio) {
-            let prio_dbg = prio
-                .map(|p| p.to_string())
-                .unwrap_or_else(|| "(max)".into());
+            let prio_dbg = prio.map_or_else(|| "(max)".into(), |p| p.to_string());
             eprintln!("Warning: sched_setscheduler(SCHED_FIFO, prio={prio_dbg}) failed: {err}");
         }
         // Affinity

--- a/doser_hardware/src/hx711.rs
+++ b/doser_hardware/src/hx711.rs
@@ -5,6 +5,13 @@ use crate::error::Result;
 use crate::util::{busy_wait_min_1us, wait_until_low_with_timeout};
 use doser_traits::clock::MonotonicClock;
 
+/// Sign bit of the HX711's 24-bit two's-complement conversion result (bit 23).
+const SIGN_BIT_24: i32 = 0x0080_0000;
+
+/// Mask covering the 24 valid data bits of a conversion result. Bits above this are
+/// filled in from [`SIGN_BIT_24`] to sign-extend into `i32`.
+const DATA_MASK_24: i32 = 0x00FF_FFFF;
+
 pub struct Hx711 {
     dt: rppal::gpio::InputPin,
     sck: rppal::gpio::OutputPin,
@@ -16,19 +23,23 @@ pub struct Hx711 {
 }
 
 impl Hx711 {
+    /// Construct a driver over already-claimed DT/SCK pins, leaving SCK idle low.
+    ///
+    /// Infallible: `rppal`'s `set_low` does not report failure and nothing else here can
+    /// fail, so this returns `Self` rather than a `Result` that could only ever be `Ok`.
     pub fn new(
         dt_pin: rppal::gpio::InputPin,
         mut sck_pin: rppal::gpio::OutputPin,
         gain_pulses: u8,
         data_ready_timeout: Duration,
-    ) -> Result<Self> {
+    ) -> Self {
         sck_pin.set_low(); // clock idle low
-        Ok(Self {
+        Self {
             dt: dt_pin,
             sck: sck_pin,
             gain_pulses,
             data_ready_timeout,
-        })
+        }
     }
 
     pub fn read_with_timeout(&mut self, timeout: Duration) -> Result<i32> {
@@ -70,8 +81,8 @@ impl Hx711 {
         }
 
         // Sign extend 24-bit
-        if (value & 0x800000) != 0 {
-            value |= !0xFFFFFF;
+        if (value & SIGN_BIT_24) != 0 {
+            value |= !DATA_MASK_24;
         }
         trace!(raw = value, "hx711 raw read");
         Ok(value)

--- a/doser_hardware/src/lib.rs
+++ b/doser_hardware/src/lib.rs
@@ -232,7 +232,9 @@ pub mod pacing {
                         tv_sec: 0,
                         tv_nsec: 0,
                     };
-                    if clock_gettime(CLOCK_MONOTONIC, &mut now_ts) == 0 {
+                    // `clock_gettime` takes `tp: *mut timespec` — the kernel writes the
+                    // current time through it, so this must stay a mutable raw pointer.
+                    if clock_gettime(CLOCK_MONOTONIC, &raw mut now_ts) == 0 {
                         let (sec, nsec) =
                             add_duration_to_timespec(now_ts.tv_sec, now_ts.tv_nsec, delta);
                         let target = timespec {
@@ -240,10 +242,13 @@ pub mod pacing {
                             tv_nsec: nsec,
                         };
                         loop {
+                            // `rqtp` is `*const timespec` (the kernel only reads the
+                            // requested deadline); `rmtp` is the `*mut` out-param and we
+                            // pass null because an absolute deadline needs no remainder.
                             let rc = clock_nanosleep(
                                 CLOCK_MONOTONIC,
                                 TIMER_ABSTIME,
-                                &target,
+                                &raw const target,
                                 std::ptr::null_mut(),
                             );
                             if rc == 0 {
@@ -474,7 +479,7 @@ pub mod hardware {
                 .map_err(|e| HwError::Gpio(format!("get HX711 SCK pin: {e}")))?
                 .into_output_low();
             // Channel A / gain 128: 1 extra SCK pulse after the 24 data bits (25 total).
-            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(150))?;
+            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(150));
             Ok(Self { hx })
         }
 
@@ -500,7 +505,7 @@ pub mod hardware {
                 data_ready_timeout_ms
             };
             // Channel A / gain 128: 1 extra SCK pulse after the 24 data bits (25 total).
-            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(drt))?;
+            let hx = Hx711::new(dt, sck, 1, Duration::from_millis(drt));
             Ok(Self { hx })
         }
 
@@ -534,7 +539,8 @@ pub mod hardware {
     }
 
     impl HardwareMotor {
-        /// Create a motor from GPIO pin numbers. EN is taken from the DOSER_EN_PIN env var if present.
+        /// Create a motor from GPIO pin numbers. EN is taken from the `DOSER_EN_PIN` env
+        /// var if present.
         pub fn try_new(step_pin: u8, dir_pin: u8) -> HwResult<Self> {
             let en_env = std::env::var("DOSER_EN_PIN")
                 .ok()
@@ -600,7 +606,7 @@ pub mod hardware {
                         continue;
                     }
 
-                    let period_us = (1_000_000u32 / sps_val).max(1) as u64; // us
+                    let period_us = u64::from((1_000_000u32 / sps_val).max(1)); // us
                     // Rising edge
                     step.set_high();
                     spin_delay_min();
@@ -696,14 +702,29 @@ pub mod hardware {
         }
     }
 
-    /// Return average jitter in microseconds over the last window (approximate).
     impl HardwareMotor {
+        /// Return average jitter in microseconds over the last window (approximate).
+        #[must_use]
         pub fn avg_jitter_us(&self) -> u32 {
             self.avg_jitter_us.load(Ordering::Relaxed)
         }
     }
 
     /// Very small spin to make edges clean.
+    ///
+    /// Note this is *not* where the STEP pulse-width guarantee comes from: the body is a
+    /// single `spin_loop()` hint (~1 cycle on aarch64), and every call site follows it
+    /// immediately with [`crate::util::busy_wait_min_1us`], whose `Instant` deadline is
+    /// the actual minimum-width guarantee. See `docs/ops/HARDWARE_LESSONS.md` Lesson 1.
+    #[allow(
+        clippy::inline_always,
+        reason = "Body is a single `spin_loop()` intrinsic, so an out-of-line call would \
+                  cost far more than the body — one of the cases where `inline(always)` is \
+                  correct. It also sits in the bit-banged STEP path, where HARDWARE_LESSONS \
+                  Lesson 1 records a real Pi 5 fault caused by codegen-level timing \
+                  assumptions; changing codegen there is a deliberate decision, not a \
+                  drive-by in a lint pass."
+    )]
     #[inline(always)]
     fn spin_delay_min() {
         std::hint::spin_loop();
@@ -716,9 +737,10 @@ pub mod hardware {
         };
 
         // Try to set FIFO priority (requires CAP_SYS_NICE); ignore EPERM with warning upstream
-        // `sched_setscheduler` takes a `*const sched_param`, so a shared borrow is enough.
+        // `sched_setscheduler` takes `param: *const sched_param` — the kernel only reads
+        // it, so `&raw const` is the exact match for the signature.
         let param = sched_param { sched_priority: 10 };
-        let rc = unsafe { sched_setscheduler(0, SCHED_FIFO, &param) };
+        let rc = unsafe { sched_setscheduler(0, SCHED_FIFO, &raw const param) };
         if rc != 0 {
             let err = std::io::Error::last_os_error();
             if err.raw_os_error() != Some(libc::EPERM) {


### PR DESCRIPTION
Follow-up to #25, closing the two gaps that pass review but rot silently.

## Release-profile clippy

Every crate declares:

```rust
#![cfg_attr(all(not(debug_assertions), not(test)),
             deny(clippy::all, clippy::pedantic, clippy::nursery))]
```

and CLAUDE.md says lints are denied in release — but CI only ever ran the debug profile, so those denials were never exercised. The result: **321 errors** had accumulated, and because compilation died in `doser_traits`, the four crates downstream of it had *never* been release-linted at all. #25 cleared them; without this step it happens again.

The gap is real, not theoretical — the lints hid actual defects, including four redundant clones per dose run in `run_with_sampler` and a hand-rolled `abs_diff` that was exactly `i32::abs_diff`.

Verified locally: `cargo clippy --release --workspace --all-targets -- -D warnings` exits clean on current master.

## Dependabot

#25 pinned all 7 actions to commit SHAs, which closes the moved-tag hijack vector — but a SHA never updates itself. Without automation the repo sits on stale actions indefinitely, which is exactly how `rustsec/audit-check` and `softprops/action-gh-release` ended up stranded on the deprecated **node16** runtime and had to be force-bumped in #25.

Dependabot understands the trailing `# vN` comments and updates the SHA and comment together, so the pins stay both current and legible. Minor/patch bumps are grouped into one weekly PR; majors stay separate, since those carry breaking input changes.

Not included: a `cargo` ecosystem entry. Worth adding given `cargo audit`/`cargo deny` run here, but it is a bigger stream of PRs and a separate decision.

## Note

The `Security` workflow had not run since 2026-04-17 and had never fired on a pull request, despite declaring `pull_request:` since 2025-10-19 — consistent with GitHub auto-disabling it over the ~58-day inactivity gap. A manual dispatch on master revived it and both jobs pass (`cargo-audit` ✅, `cargo-deny` ✅), which also validates #25's forced v1→v2 action bumps. **This PR is the first real test of whether it now fires on `pull_request`** — if `cargo-audit` and `cargo-deny` appear in the checks below, it is fully back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)